### PR TITLE
[YSA-25/Routine] DatePicker 구현

### DIFF
--- a/core/designsystem/src/main/kotlin/com/pillsquad/yakssok/core/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/kotlin/com/pillsquad/yakssok/core/designsystem/theme/Color.kt
@@ -62,6 +62,6 @@ object YakssokLightColor : YakssokColor {
     override val subPurple = Color(0xFF7C24DB)
     override val subYellow = Color(0xFFFFB012)
     override val subGreen = Color(0xFF3ADE4D)
-    override val subBlue = Color(0xFF3C99D7)
+    override val subBlue = Color(0xFF40B0FA)
     override val subPink = Color(0xFFD224DB)
 }

--- a/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/RoutineScreen.kt
+++ b/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/RoutineScreen.kt
@@ -24,7 +24,6 @@ import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
-
 @Composable
 internal fun RoutineRoute(
     onNavigateBack: () -> Unit
@@ -63,7 +62,6 @@ internal fun RoutineScreen(
         TimePicker(
             initialTime = initialTime,
         ) {
-            Log.e("PickerInit", "onValueChange time called with: $it")
             selectedTime = it
         }
 
@@ -72,7 +70,6 @@ internal fun RoutineScreen(
         DatePicker(
             initialDate = initialDate,
         ) {
-            Log.e("PickerInit", "onValueChange date called with: $it")
             selectedDate = it
         }
     }

--- a/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/RoutineScreen.kt
+++ b/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/RoutineScreen.kt
@@ -1,5 +1,6 @@
 package com.pillsquad.yakssok.feature.routine
 
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -15,45 +16,63 @@ import com.pillsquad.yakssok.core.designsystem.theme.YakssokTheme
 import com.pillsquad.yakssok.core.ui.ext.yakssokDefault
 import com.pillsquad.yakssok.feature.routine.component.DatePicker
 import com.pillsquad.yakssok.feature.routine.component.TimePicker
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
+
 @Composable
 internal fun RoutineRoute(
     onNavigateBack: () -> Unit
 ) {
-
-    BackHandler {
-        onNavigateBack
+    val initialTime by remember {
+        mutableStateOf(
+            Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).time
+        )
+    }
+    val initialDate by remember {
+        mutableStateOf(
+            Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+        )
     }
 
-    RoutineScreen()
+    RoutineScreen(
+        initialTime = initialTime,
+        initialDate = initialDate
+    )
 }
 
-@OptIn(ExperimentalTime::class)
 @Composable
 internal fun RoutineScreen(
-
+    initialTime: LocalTime,
+    initialDate: LocalDate
 ) {
-    var selectedTime by remember { mutableStateOf(Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).time) }
-    var selectedDate by remember { mutableStateOf(Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date) }
+    var selectedTime by remember { mutableStateOf(initialTime) }
+    var selectedDate by remember { mutableStateOf(initialDate) }
+
+    Log.e("DatePicker", "selectedTime: $selectedTime")
+    Log.e("DatePicker", "selectedDate: $selectedDate")
 
     Column(
         modifier = Modifier.yakssokDefault(YakssokTheme.color.grey100)
     ) {
         TimePicker(
-            initialTime = selectedTime,
+            initialTime = initialTime,
         ) {
+            Log.e("PickerInit", "onValueChange time called with: $it")
             selectedTime = it
         }
 
         Spacer(modifier = Modifier.height(40.dp))
 
         DatePicker(
-            initialDate = selectedDate,
+            initialDate = initialDate,
         ) {
+            Log.e("PickerInit", "onValueChange date called with: $it")
             selectedDate = it
         }
     }

--- a/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/RoutineScreen.kt
+++ b/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/RoutineScreen.kt
@@ -2,14 +2,18 @@ package com.pillsquad.yakssok.feature.routine
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.pillsquad.yakssok.core.designsystem.theme.YakssokTheme
 import com.pillsquad.yakssok.core.ui.ext.yakssokDefault
+import com.pillsquad.yakssok.feature.routine.component.DatePicker
 import com.pillsquad.yakssok.feature.routine.component.TimePicker
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -34,7 +38,7 @@ internal fun RoutineScreen(
 
 ) {
     var selectedTime by remember { mutableStateOf(Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).time) }
-
+    var selectedDate by remember { mutableStateOf(Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date) }
 
     Column(
         modifier = Modifier.yakssokDefault(YakssokTheme.color.grey100)
@@ -43,6 +47,14 @@ internal fun RoutineScreen(
             initialTime = selectedTime,
         ) {
             selectedTime = it
+        }
+
+        Spacer(modifier = Modifier.height(40.dp))
+
+        DatePicker(
+            initialDate = selectedDate,
+        ) {
+            selectedDate = it
         }
     }
 }

--- a/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/component/DatePicker.kt
+++ b/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/component/DatePicker.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -50,7 +51,7 @@ internal fun DatePicker(
         items = yearItems
     )
     val monthPickerState = rememberPickerState(
-        initialIndex = initialDate.month.number - 1,
+        initialIndex = initialDate.month.number,
         items = monthItems
     )
 
@@ -66,6 +67,19 @@ internal fun DatePicker(
         initialIndex = initialDate.day - 1,
         items = dayItems
     )
+
+    LaunchedEffect(yearPickerState.selectedItem, monthPickerState.selectedItem) {
+        val maxDays = getDaysInMonth(
+            year = yearPickerState.selectedItem,
+            month = monthPickerState.selectedItem
+        )
+
+        dayPickerState.updateItems(maxDays)
+
+        if (dayPickerState.selectedItem > maxDays.last()) {
+            dayPickerState.updateSelectedIndex(maxDays.size - 1)
+        }
+    }
 
     Box(
         modifier = modifier,
@@ -135,7 +149,7 @@ internal fun DatePicker(
             ) {
                 PickerItem(
                     modifier = Modifier.weight(0.9f),
-                    items = dayItems,
+                    items = dayPickerState.items,
                     state = dayPickerState,
                     visibleItemsCount = visibleItemsCount,
                     style = style,
@@ -189,7 +203,9 @@ private fun onPickerValueChange(
 ) {
     val year = yearState.selectedItem
     val month = monthState.selectedItem
-    val day = dayState.selectedItem
+    val maxDay = getDaysInMonth(year, month).last()
+
+    val day = dayState.selectedItem.coerceAtMost(maxDay)
 
     val newDate = LocalDate(year, month, day)
 

--- a/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/component/PickerItem.kt
+++ b/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/component/PickerItem.kt
@@ -22,8 +22,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import com.pillsquad.yakssok.feature.routine.model.CurveEffect
 import com.pillsquad.yakssok.feature.routine.model.PickerState
 import com.pillsquad.yakssok.feature.routine.model.PickerStyle
@@ -96,7 +94,7 @@ internal fun <T> PickerItem(
             .collect { adjustedIndex ->
                 if (adjustedIndex != null && adjustedIndex != state.selectedIndex.value) {
                     state.updateSelectedIndex(adjustedIndex)
-                    onValueChange(items[adjustedIndex])
+//                    onValueChange(items[adjustedIndex])
                 }
             }
     }
@@ -104,7 +102,7 @@ internal fun <T> PickerItem(
     val totalItemHeight = itemHeightDp + style.itemSpacing
     val totalItemHeightPx = totalItemHeight.toPx()
 
-    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+    Box(modifier = modifier) {
         LazyColumn(
             state = listState,
             flingBehavior = flingBehavior,
@@ -138,7 +136,6 @@ internal fun <T> PickerItem(
 
                 Text(
                     text = item?.let { itemFormatter(it) } ?: "",
-                    textAlign = TextAlign.Center,
                     maxLines = 1,
                     style = style.textStyle,
                     color = style.textColor.copy(alpha = alpha),

--- a/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/component/SelectorBackground.kt
+++ b/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/component/SelectorBackground.kt
@@ -1,0 +1,43 @@
+package com.pillsquad.yakssok.feature.routine.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import com.pillsquad.yakssok.feature.routine.model.PickerSelector
+import com.pillsquad.yakssok.feature.routine.model.PickerStyle
+
+@Composable
+fun SelectorBackground(
+    modifier: Modifier = Modifier,
+    style: PickerStyle,
+    selector: PickerSelector
+) {
+    val lineHeight = with(LocalDensity.current) { style.textStyle.lineHeight.toDp() }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(lineHeight + 16.dp)
+    ) {
+        HorizontalDivider(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth(),
+            thickness = 1.dp,
+            color = selector.color
+        )
+        HorizontalDivider(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth(),
+            thickness = 1.dp,
+            color = selector.color
+        )
+    }
+}

--- a/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/component/TimePicker.kt
+++ b/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/component/TimePicker.kt
@@ -75,7 +75,6 @@ fun TimePicker(
             verticalAlignment = Alignment.CenterVertically
         ) {
             PickerItem(
-                items = amPmItems,
                 state = amPmPickerState,
                 visibleItemsCount = visibleItemsCount,
                 style = style,
@@ -99,7 +98,6 @@ fun TimePicker(
             ) {
                 PickerItem(
                     modifier = Modifier.weight(0.9f),
-                    items = hourItems,
                     state = hourPickerState,
                     visibleItemsCount = visibleItemsCount,
                     style = style,
@@ -145,7 +143,6 @@ fun TimePicker(
             ) {
                 PickerItem(
                     modifier = Modifier.weight(0.9f),
-                    items = minuteItems,
                     state = minutePickerState,
                     visibleItemsCount = visibleItemsCount,
                     style = style,

--- a/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/component/TimePicker.kt
+++ b/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/component/TimePicker.kt
@@ -5,9 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -17,14 +15,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.pillsquad.yakssok.core.designsystem.theme.YakssokTheme
 import com.pillsquad.yakssok.feature.routine.model.CurveEffect
+import com.pillsquad.yakssok.feature.routine.model.PickerDefaults
 import com.pillsquad.yakssok.feature.routine.model.PickerSelector
 import com.pillsquad.yakssok.feature.routine.model.PickerState
 import com.pillsquad.yakssok.feature.routine.model.PickerStyle
-import com.pillsquad.yakssok.feature.routine.model.PickerDefaults
 import com.pillsquad.yakssok.feature.routine.model.rememberPickerState
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalTime
@@ -35,7 +32,7 @@ import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
 @Composable
-internal fun TimePicker(
+fun TimePicker(
     modifier: Modifier = Modifier,
     initialTime: LocalTime = Clock.System.now()
         .toLocalDateTime(TimeZone.currentSystemDefault()).time,
@@ -185,9 +182,9 @@ private fun onPickerValueChange(
     val hour = hourState.selectedItem
     val minute = minuteState.selectedItem
 
-    val adjustedHour = when (amPm) {
-        "오전" -> if (hour == 12) 0 else hour
-        "오후" -> if (hour != 12) hour + 12 else 12
+    val adjustedHour = when {
+        amPm == "오전" && hour == 12 -> 0
+        amPm == "오후" && hour != 12 -> hour + 12
         else -> hour
     }
 

--- a/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/model/PickerDefaults.kt
+++ b/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/model/PickerDefaults.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.pillsquad.yakssok.core.designsystem.theme.YakssokTheme
 
-object TimePickerDefaults {
+object PickerDefaults {
     @Composable
     fun pickerStyle(
         textStyle: TextStyle = YakssokTheme.typography.header2,

--- a/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/model/PickerState.kt
+++ b/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/model/PickerState.kt
@@ -1,5 +1,6 @@
 package com.pillsquad.yakssok.feature.routine.model
 
+import android.util.Log
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
@@ -10,17 +11,29 @@ import kotlinx.coroutines.flow.StateFlow
 class PickerState<T>(
     val lazyListState: LazyListState,
     val initialIndex: Int,
-    private val items: List<T>
+    private var _items: List<T>
 ) {
     private val _selectedIndex = MutableStateFlow(initialIndex)
     val selectedIndex: StateFlow<Int>
         get() = _selectedIndex
 
+    val items: List<T>
+        get() = _items
+
     val selectedItem: T
         get() = items.getOrElse(_selectedIndex.value) { items.first() }
 
     fun updateSelectedIndex(newIndex: Int) {
+        Log.d("PickerInit", "items: $items")
+        Log.d("PickerInit", "updateSelectedIndex: $newIndex")
         _selectedIndex.value = newIndex.coerceIn(0, items.size - 1)
+    }
+
+    fun updateItems(newItems: List<T>) {
+        _items = newItems
+        if (_selectedIndex.value >= _items.size) {
+            _selectedIndex.value = (_items.size - 1).coerceAtLeast(0)
+        }
     }
 }
 

--- a/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/model/PickerState.kt
+++ b/feature/routine/src/main/java/com/pillsquad/yakssok/feature/routine/model/PickerState.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -11,28 +12,30 @@ import kotlinx.coroutines.flow.StateFlow
 class PickerState<T>(
     val lazyListState: LazyListState,
     val initialIndex: Int,
-    private var _items: List<T>
+    items: List<T>
 ) {
+    private val _items = mutableStateOf(items)
+    val items: List<T> get() = _items.value
+
     private val _selectedIndex = MutableStateFlow(initialIndex)
     val selectedIndex: StateFlow<Int>
         get() = _selectedIndex
 
-    val items: List<T>
-        get() = _items
-
     val selectedItem: T
         get() = items.getOrElse(_selectedIndex.value) { items.first() }
 
+    val suppressScrollSync = mutableStateOf(false)
+    val isUserScrolling = mutableStateOf(false)
+
     fun updateSelectedIndex(newIndex: Int) {
-        Log.d("PickerInit", "items: $items")
-        Log.d("PickerInit", "updateSelectedIndex: $newIndex")
         _selectedIndex.value = newIndex.coerceIn(0, items.size - 1)
     }
 
     fun updateItems(newItems: List<T>) {
-        _items = newItems
-        if (_selectedIndex.value >= _items.size) {
-            _selectedIndex.value = (_items.size - 1).coerceAtLeast(0)
+        _items.value = newItems
+
+        if (_selectedIndex.value >= items.size) {
+            _selectedIndex.value = (items.size - 1).coerceAtLeast(0)
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ kotlin = "2.2.0"
 # https://github.com/Kotlin/kotlinx.serialization
 kotlinxSerializationJson = "1.9.0"
 # https://github.com/Kotlin/kotlinx-datetime/releases
-kotlinxDatetime = "0.7.0"
+kotlinxDatetime = "0.7.1"
 # https://github.com/Kotlin/kotlinx.collections.immutable
 kotlinxImmutable = "0.4.0"
 


### PR DESCRIPTION
## 🚀 작업 내용
- TimePicker 수정
- TimePicker 기반으로 DatePicker 구현

## ✅ 작업 상세
- TimePicker와 달리 DatePicker는 년, 월에 따라서 일자가 다르기 때문에 해당 부분을 고려해줄 필요가 있었음
- 이를 위해서 items를 PickerState 내부에 넣고, DatePickerState의 변경과 scroll state의 변경을 위해서 flag를 PickerState에 추가함

1. 월, 일이 7월 15일이 아니라 7월 13일로 맞춰지는 버그
    1. DatePicker의 onPickerValueChange에 들어가는 month 값이 -1로 들어가고 있었음. 해당 값을 수정하여 해결.
    2. 이런 과정을 거치기 위해서 현재 선택되고 있는 값이 무엇인지 로그를 일일이 다 찍으면서 확인
    3. 전체적인 흐름 파악을 위해 DatePicker 디버깅
2. 시간, 날짜가 모두 현재의 값이 들어가지 않았음
    1. PickerItem에 오타가 있었음. 깃헙 소스에서도 있는 거였음
    2. getStartIndexForInfiniteScroll에 itemSize에 items.size가 들어가야 하는데 itemHeightPixels가 들어갔음
3. 년/월 변경해도 날짜 목록이 1 ~ 31 혹은 1 ~ 30 고정되는 현상
    1. PickerItem으로 넘겨주는 items 파라미터 삭제
    2. PickerState에 items를 삽입
    3. datePicker에서 year/month의 변경을 감지하고 items를 PickerState에 넣어주도록 함.
    4. PickerItem에서는 state 파라미터의 items를 기반으로 계산하도록 변경함
4. 7월 15일에서 6월로 가면 6월 18일이 됨
    1. year, month의 값이 변경되면 day의 selectedIndex와 items를 수정하도록 했었음
    2. 이렇게 하면 scroll state에서 현재 위치는 수정이 되어있지 않은데 items의 size가 변경이 되었기 때문에 원하지 않는 날짜가 보이고, 실제로 선택되는 날짜는 정상적으로 나옴
    3. DatePicker의 year, month를 감지하는 LaunchedEffect에서 직접 스크롤을 조정해야함
    4. 하지만 스크롤을 직접 조정하면 PickerItem에서 listState의 변경을 감지하고 selectedIndex와 선택된 값을 변경하여 예상하기 어려운 결과가 나옴
    5. 따라서 PickerState에 flag를 두고 DatePicker의 LaunchedEffect가 아직 진행 중이면 PickerItem에서 collect 부분에서 값 변경이 없도록 함.
    6. 하지만 day의 스크롤을 조정하고 년, 월을 건드리면 day가 변경이 되는 버그가 나타남
    7. pickerstate에 isUserScrolling 추가
    8. 내부에서 아직 스크롤 중인게 확인이 되면 DatePicker에서 업데이트를 보류하도록 함
    9. 거의 완벽히 동작함

이후 정리 예정...

## 📹 스크린샷

https://github.com/user-attachments/assets/b2ce9dce-7a48-4c58-81ea-b8faea84e58d


## TODO
- 버그가 일부 존재하기 때문에 이후 세부사항 작업에서 수정 요망