### PR TITLE
[YSA-57/Calendar] UI 수정 및 API 연동

### DIFF
--- a/core/data/src/main/kotlin/com/pillsquad/yakssok/core/data/repository/MedicationRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/pillsquad/yakssok/core/data/repository/MedicationRepositoryImpl.kt
@@ -7,15 +7,27 @@ import com.pillsquad.yakssok.core.domain.repository.MedicationRepository
 import com.pillsquad.yakssok.core.model.Medication
 import com.pillsquad.yakssok.core.model.MyRoutine
 import com.pillsquad.yakssok.core.network.datasource.MedicationDataSource
+import com.pillsquad.yakssok.datastore.UserLocalDataSource
+import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
 
 class MedicationRepositoryImpl @Inject constructor(
-    private val medicationDataSource: MedicationDataSource
+    private val medicationDataSource: MedicationDataSource,
+    private val userLocalDataSource: UserLocalDataSource
 ) : MedicationRepository {
     override suspend fun postMedication(medication: Medication): Result<Unit> {
         val params = medication.toPostMedicationRequest()
 
-        return medicationDataSource.postMedication(params = params).toResult()
+        val result = medicationDataSource.postMedication(params = params).toResult(
+            transform = { it }
+        )
+
+        result.onSuccess {
+            val currentCount = userLocalDataSource.medicationCountFlow.firstOrNull() ?: 0
+            userLocalDataSource.saveMedicationCount(currentCount + 1)
+        }
+
+        return result
     }
 
     override suspend fun putEndMedication(medicationId: Long): Result<Unit> {

--- a/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/CalendarViewModel.kt
+++ b/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/CalendarViewModel.kt
@@ -1,20 +1,153 @@
 package com.pillsquad.yakssok.feature.calendar
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pillsquad.yakssok.core.domain.usecase.GetUserProfileListUseCase
+import com.pillsquad.yakssok.core.domain.usecase.GetUserRoutineUseCase
+import com.pillsquad.yakssok.core.domain.usecase.UpdateRoutineTakenUseCase
+import com.pillsquad.yakssok.core.model.UserCache
+import com.pillsquad.yakssok.feature.calendar.model.CalendarCacheManager
+import com.pillsquad.yakssok.feature.calendar.model.CalendarConfig
 import com.pillsquad.yakssok.feature.calendar.model.CalendarUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+import kotlinx.datetime.number
+import kotlinx.datetime.plus
 import javax.inject.Inject
 
 @HiltViewModel
 class CalendarViewModel @Inject constructor(
-): ViewModel(){
+    private val getUserProfileListUseCase: GetUserProfileListUseCase,
+    private val getUserRoutineUseCase: GetUserRoutineUseCase,
+    private val updateRoutineTakenUseCase: UpdateRoutineTakenUseCase,
+) : ViewModel() {
     private val _uiState = MutableStateFlow(CalendarUiModel())
     val uiState = _uiState.asStateFlow()
 
+    private val config = CalendarConfig()
+
+    private val cacheManager
+        get() = CalendarCacheManager(
+            routineCache = uiState.value.routineCache,
+            takenCache = uiState.value.takenCache
+        )
+
+    init {
+        loadUserAndRoutines()
+    }
+
     fun updateSelectedDate(date: LocalDate) {
         _uiState.value = _uiState.value.copy(selectedDate = date)
+    }
+
+    fun onMateClick(userIdx: Int) {
+        _uiState.value = _uiState.value.copy(selectedUserIdx = userIdx)
+    }
+
+    fun onRoutineClick(routineId: Int) {
+        val userIdx = uiState.value.selectedUserIdx
+        val date = uiState.value.selectedDate
+
+        val currentRoutines = uiState.value.routineCache[userIdx]?.get(date) ?: return
+        val updated = currentRoutines.map {
+            if (it.routineId == routineId) it.copy(isTaken = !it.isTaken) else it
+        }
+
+        cacheManager.updateRoutine(userIdx, date, updated)
+
+        viewModelScope.launch {
+            updateRoutineTakenUseCase(routineId)
+        }
+    }
+
+    fun loadUserAndRoutines() {
+        viewModelScope.launch {
+            getUserProfileListUseCase()
+                .onSuccess { users ->
+                    _uiState.value = _uiState.value.copy(userList = users)
+
+                    val (startDate, endDate) = getStartEndDate()
+
+                    // 내 루틴
+                    loadUserRoutine(userId = null, userIdx = 0, startDate, endDate)
+
+                    // 친구 루틴
+                    users.drop(1).forEachIndexed { index, friend ->
+                        val userIdx = index + 1
+                        loadUserRoutine(userId = friend.id, userIdx, startDate, endDate)
+                    }
+                }
+                .onFailure {
+                    Log.e("CalendarViewModel", "getUserProfileList failed", it)
+                    // TODO: Toast
+                }
+        }
+    }
+
+    fun loadDataForPage(page: Int) {
+        val year = config.yearRange.first + (page / 12)
+        val month = (page % 12) + 1
+
+        val startDate = LocalDate(year, month, 1)
+        val endDate = startDate.plus(1, DateTimeUnit.MONTH).minus(1, DateTimeUnit.DAY)
+
+        viewModelScope.launch {
+            // 내 루틴
+            loadUserRoutine(userId = null, userIdx = uiState.value.selectedUserIdx, startDate, endDate)
+
+            // 친구 루틴
+            uiState.value.userList.forEachIndexed { idx, user ->
+                if (idx != uiState.value.selectedUserIdx) {
+                    loadUserRoutine(user.id, idx, startDate, endDate)
+                }
+            }
+        }
+    }
+
+    private suspend fun loadUserRoutine(
+        userId: Int? = null,
+        userIdx: Int,
+        startDate: LocalDate,
+        endDate: LocalDate
+    ) {
+        val result = if (userId == null) {
+            getUserRoutineUseCase(startDate, endDate)
+        } else {
+            getUserRoutineUseCase(userId = userId, startDate = startDate, endDate = endDate)
+        }
+
+        result.onSuccess { cache ->
+            cacheManager.merge(userIdx, cache)
+            updateUserListWithRoutineEmptyState(userIdx, cache)
+        }.onFailure {
+            Log.e("CalendarViewModel", "getRoutine failed for userId=$userId", it)
+            // TODO: Toast
+        }
+    }
+
+    private fun updateUserListWithRoutineEmptyState(userIdx: Int, cache: UserCache) {
+        _uiState.value = _uiState.value.copy(
+            userList = uiState.value.userList.mapIndexed { idx, user ->
+                if (idx == userIdx) {
+                    user.copy(isNotMedicine = cache.routineCache.isEmpty())
+                } else user
+            }
+        )
+    }
+
+    private fun getStartEndDate(): Pair<LocalDate, LocalDate> {
+        val year = uiState.value.selectedDate.year
+        val month = uiState.value.selectedDate.month.number
+
+        val startDate = LocalDate(year, month, 1)
+        val endDate = startDate.plus(1, DateTimeUnit.MONTH).minus(1, DateTimeUnit.DAY)
+
+        return startDate to endDate
     }
 }

--- a/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/component/Calendar.kt
+++ b/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/component/Calendar.kt
@@ -1,5 +1,6 @@
 package com.pillsquad.yakssok.feature.calendar.component
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -76,7 +77,7 @@ internal fun Calendar(
     }
 
     Column(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth()
     ) {
         CalendarHeader(
             yearMonth = currentYearMonth,
@@ -102,7 +103,7 @@ internal fun Calendar(
 
         HorizontalPager(
             modifier = Modifier.fillMaxWidth(),
-            state = pagerState
+            state = pagerState,
         ) { page ->
             val date = YearMonth(
                 year = config.yearRange.first + (page / 12),

--- a/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/component/CalendarMonthItem.kt
+++ b/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/component/CalendarMonthItem.kt
@@ -1,9 +1,9 @@
 package com.pillsquad.yakssok.feature.calendar.component
 
-import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,14 +12,10 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -45,9 +41,7 @@ internal fun CalendarMonthItem(
     val daysInMonth = currentYearMonth.numberOfDays
     val paddedDates = buildList {
         // 앞쪽 공백 (첫 주 요일 위치 맞추기)
-        repeat(firstDayOfWeek) {
-            add(null)
-        }
+        repeat(firstDayOfWeek) { add(null) }
         // 날짜 채우기
         for (day in 1..daysInMonth) {
             add(LocalDate(currentYearMonth.year, currentYearMonth.month, day))
@@ -58,12 +52,16 @@ internal fun CalendarMonthItem(
         }
     }
 
+    val weeks = paddedDates.chunked(7)
+    val totalWeeks = 6
+
     Column(
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.Top
     ) {
         Week()
 
-        paddedDates.chunked(7).forEach { week ->
+        weeks.forEach { week ->
             Row(modifier = Modifier.fillMaxWidth()) {
                 week.forEach { date ->
                     Box(
@@ -81,6 +79,22 @@ internal fun CalendarMonthItem(
                                 onDateSelected = onDateSelected
                             )
                         }
+                    }
+                }
+            }
+        }
+
+        repeat(totalWeeks - weeks.size) {
+            Row(modifier = Modifier.fillMaxWidth()) {
+                repeat(7) {
+                    Box(
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Spacer(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(0.7313f)
+                        )
                     }
                 }
             }
@@ -142,10 +156,12 @@ private fun CalendarDay(
         Spacer(modifier = Modifier.height(1.dp))
 
         if (isFuture) {
+            Spacer(modifier = Modifier.height(1.dp))
+
             Box(
                 modifier = Modifier
                     .alpha(0.9f)
-                    .padding(start = 8.dp, end = 8.dp, bottom = 4.dp)
+                    .padding(start = 7.dp, end = 7.dp, bottom = 4.dp)
                     .fillMaxWidth()
                     .aspectRatio(1f)
                     .background(

--- a/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/model/CalendarCacheManager.kt
+++ b/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/model/CalendarCacheManager.kt
@@ -1,0 +1,44 @@
+package com.pillsquad.yakssok.feature.calendar.model
+
+import android.util.SparseArray
+import com.pillsquad.yakssok.core.model.Routine
+import com.pillsquad.yakssok.core.model.UserCache
+import kotlinx.datetime.LocalDate
+
+class CalendarCacheManager(
+    private val routineCache: SparseArray<MutableMap<LocalDate, List<Routine>>>,
+    private val takenCache: SparseArray<MutableMap<LocalDate, Boolean>>
+) {
+
+    fun merge(userIdx: Int, cache: UserCache) {
+        val currentRoutine = routineCache[userIdx] ?: mutableMapOf()
+        val newRoutine = currentRoutine.toMutableMap().apply {
+            cache.routineCache.forEach { (date, list) -> this[date] = list }
+        }
+        routineCache.put(userIdx, newRoutine)
+
+        val currentTaken = takenCache[userIdx] ?: mutableMapOf()
+        val newTaken = currentTaken.toMutableMap().apply {
+            cache.takenCache.forEach { (date, taken) -> this[date] = taken }
+        }
+        takenCache.put(userIdx, newTaken)
+    }
+
+    fun updateRoutine(userIdx: Int, date: LocalDate, routines: List<Routine>) {
+        val routineMap = routineCache[userIdx] ?: mutableMapOf()
+        routineMap[date] = routines
+        routineCache.put(userIdx, routineMap)
+
+        updateTaken(userIdx, date)
+    }
+
+    fun updateTaken(userIdx: Int, date: LocalDate) {
+        val routineMap = routineCache[userIdx] ?: return
+        val routineList = routineMap[date] ?: return
+        val allTaken = routineList.all { it.isTaken }
+
+        val takenMap = takenCache[userIdx] ?: mutableMapOf()
+        takenMap[date] = allTaken
+        takenCache.put(userIdx, takenMap)
+    }
+}

--- a/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/model/CalendarUiModel.kt
+++ b/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/model/CalendarUiModel.kt
@@ -7,9 +7,9 @@ import com.pillsquad.yakssok.core.model.Routine
 import kotlinx.datetime.LocalDate
 
 data class CalendarUiModel(
+    val selectedUserIdx: Int = 0,
     val selectedDate: LocalDate = LocalDate.today(),
-    val userLists: List<User> = listOf(),
-    val selectedMate: Int = 1,
+    val userList: List<User> = listOf(),
     // userId to <먹을 날짜, 먹어야 하는 약 리스트>
     val routineCache: SparseArray<MutableMap<LocalDate, List<Routine>>> = SparseArray(),
     // userId to <먹을 날짜, 그 날짜에 약 다 먹었는가?>

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeScreen.kt
@@ -122,12 +122,8 @@ internal fun HomeRoute(
         selectedUserIdx = uiState.selectedUserIdx,
         scrollState = scrollState,
         onRefresh = onRefresh,
-        onClickUser = {
-            viewModel.onMateClick(it)
-        },
-        onSelectDate = {
-            viewModel.onSelectedDate(it)
-        },
+        onClickUser = viewModel::onMateClick,
+        onSelectDate = viewModel::onSelectedDate,
         onClickRoutine = viewModel::onRoutineClick,
         onSendMessage = {
             feedbackTarget = it
@@ -234,77 +230,6 @@ private fun HomeScreen(
             )
         }
     }
-
-//    Column(
-//        modifier = Modifier
-//            .fillMaxSize()
-//            .background(YakssokTheme.color.grey50)
-//            .systemBarsPadding()
-//    ) {
-//        YakssokTopAppBar(
-//            modifier = Modifier.padding(horizontal = 16.dp),
-//            isLogo = true,
-//            onNavigateAlert = onNavigateAlert,
-//            onNavigateMy = onNavigateMy
-//        )
-//
-//        Column(
-//            modifier = Modifier
-//                .fillMaxWidth()
-//                .background(YakssokTheme.color.grey100)
-//                .verticalScroll(scrollState)
-//        ) {
-//
-//
-//            if (showFeedBackSection) {
-//                Spacer(modifier = Modifier.height(16.dp))
-//
-//                LazyRow(
-//                    modifier = Modifier.fillMaxWidth()
-//                ) {
-//                    item {
-//                        Spacer(modifier = Modifier.width(16.dp))
-//                    }
-//                    items(userProfileList.size) { index ->
-//                        val user = userProfileList[index]
-//
-//                        if (user.notTakenCount != null) {
-//                            UserInfoCard(
-//                                id = user.id,
-//                                nickName = user.nickName,
-//                                relationName = user.relationName,
-//                                profileUrl = user.profileImage,
-//                                remainedMedicine = user.notTakenCount ?: 0,
-//                                onClick = {
-//                                    onSendMessage(user)
-//                                }
-//                            )
-//                            Spacer(modifier = Modifier.width(16.dp))
-//                        }
-//                    }
-//
-//                }
-//
-//                Spacer(modifier = Modifier.height(16.dp))
-//            }
-//
-//            HomeContent(
-//                modifier = Modifier,
-//                userProfileList = userProfileList,
-//                routineList = routineCache[selectedUserIdx]?.get(selectedDate) ?: emptyList(),
-//                selectedDate = selectedDate,
-//                selectedUserIdx = selectedUserIdx,
-//                isRounded = showFeedBackSection,
-//                isNotMedicine = userProfileList[selectedUserIdx].isNotMedicine,
-//                onClickUser = onClickUser,
-//                onSelectDate = onSelectDate,
-//                onClickRoutine = onClickRoutine,
-//                onNavigateMate = onNavigateMate,
-//                onNavigateRoutine = onNavigateRoutine,
-//                onNavigateCalendar = onNavigateCalendar
-//            )
-//        }
-//    }
 }
 
 @Composable


### PR DESCRIPTION
## 🚀 작업 내용
- API 연동
- Calendar 높이 변동되는 오류 수정

## ✅ 작업 상세
Calendar에서 현재 페이지를 기반으로 년, 월을 얻어서 prePatch 할 수 있도록 구현함
현재 페이지를 기준으로 앞, 뒤의 데이터를 미리 가져오도록 했음.
이미 불러온 데이터는 다시 불러올 필요가 없으므로 Calendar에서 Set으로 이전에 불러온 데이터를 지니고 있다가
contains를 활용하여 이미 불러온 데이터라면 다시 api 호출하지 않도록 했음

```kotlin
@Composable
internal fun Calendar(
    modifier: Modifier = Modifier,
    today: LocalDate = LocalDate.today(),
    selectedDate: LocalDate = today,
    takenCache: Map<LocalDate, Boolean>,
    config: CalendarConfig = CalendarConfig(),
    onDateSelected: (LocalDate) -> Unit,
    onLoadDataForPage: (Int) -> Unit = {}
) {
    val scope = rememberCoroutineScope()

    val initialPage =
        (selectedDate.year - config.yearRange.first) * 12 + selectedDate.month.number - 1
    val totalPages = (config.yearRange.last - config.yearRange.first + 1) * 12

    val pagerState = rememberPagerState(
        initialPage = initialPage,
        pageCount = { totalPages }
    )
    var currentPage by remember { mutableIntStateOf(initialPage) }

    val loadedPages = remember { mutableStateSetOf(currentPage) }

    val currentYearMonth by remember(pagerState.currentPage) {
        derivedStateOf {
            val year = config.yearRange.first + (pagerState.currentPage / 12)
            val month = (pagerState.currentPage % 12) + 1
            YearMonth(year, month)
        }
    }

    LaunchedEffect(pagerState.currentPage) {
        val pagesToLoad = listOf(
            pagerState.currentPage,
            pagerState.currentPage - 1,
            pagerState.currentPage + 1
        ).filter { it in 0 until totalPages }

        for (page in pagesToLoad) {
            if (!loadedPages.contains(page)) {
                onLoadDataForPage(page)
                loadedPages.add(page)
            }
        }

        if (currentPage != pagerState.currentPage) {
            currentPage = pagerState.currentPage
        }
    }
```

매번 uiState에 있는 캐시를 update 하는 것이 보일러 플레이트 코드가 많이 생겨서 CalendarCacheManager를 만들어서 
cache merge, update를 하도록 구현했음

```kotlin
class CalendarCacheManager(
    private val routineCache: SparseArray<MutableMap<LocalDate, List<Routine>>>,
    private val takenCache: SparseArray<MutableMap<LocalDate, Boolean>>
) {

    fun merge(userIdx: Int, cache: UserCache) {
        val currentRoutine = routineCache[userIdx] ?: mutableMapOf()
        val newRoutine = currentRoutine.toMutableMap().apply {
            cache.routineCache.forEach { (date, list) -> this[date] = list }
        }
        routineCache.put(userIdx, newRoutine)

        val currentTaken = takenCache[userIdx] ?: mutableMapOf()
        val newTaken = currentTaken.toMutableMap().apply {
            cache.takenCache.forEach { (date, taken) -> this[date] = taken }
        }
        takenCache.put(userIdx, newTaken)
    }

    fun updateRoutine(userIdx: Int, date: LocalDate, routines: List<Routine>) {
        val routineMap = routineCache[userIdx] ?: mutableMapOf()
        routineMap[date] = routines
        routineCache.put(userIdx, routineMap)

        updateTaken(userIdx, date)
    }

    fun updateTaken(userIdx: Int, date: LocalDate) {
        val routineMap = routineCache[userIdx] ?: return
        val routineList = routineMap[date] ?: return
        val allTaken = routineList.all { it.isTaken }

        val takenMap = takenCache[userIdx] ?: mutableMapOf()
        takenMap[date] = allTaken
        takenCache.put(userIdx, takenMap)
    }
}
```

## 📹 스크린샷
- 기능, UI 동작 영상 및 이미지 첨부

## TODO
- 남은 작업이나, 고려해야할 사항 작성