### PR TITLE
[YSA-73/Refactor] 코드 리팩토링 & 목록 변경 애니메이션

### DIFF
--- a/core/designsystem/src/main/kotlin/com/pillsquad/yakssok/core/designsystem/util/ModifierExt.kt
+++ b/core/designsystem/src/main/kotlin/com/pillsquad/yakssok/core/designsystem/util/ModifierExt.kt
@@ -2,24 +2,16 @@ package com.pillsquad.yakssok.core.designsystem.util
 
 import android.graphics.BlurMaskFilter
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Paint
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.PathOperation
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.drawOutline
-import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-
-enum class ShadowDirection { ALL, TOP, BOTTOM, START, END }
 
 fun Modifier.shadow(
     color: Color = Color.Black,
@@ -28,48 +20,24 @@ fun Modifier.shadow(
     offsetY: Dp = 0.dp,
     shape: Shape = RectangleShape,
     spread: Dp = 0.dp,
-    direction: ShadowDirection = ShadowDirection.ALL
 ) = this.drawBehind {
     val shadowSize = Size(size.width + spread.toPx(), size.height + spread.toPx())
-    val outline = shape.createOutline(shadowSize, layoutDirection, this)
+    val shadowOutline = shape.createOutline(shadowSize, layoutDirection, this)
 
-    val paint = Paint().apply { this.color = color }
+    val paint = Paint().apply {
+        this.color = color
+    }
+
     if (blur.toPx() > 0) {
         paint.asFrameworkPaint().apply {
             maskFilter = BlurMaskFilter(blur.toPx(), BlurMaskFilter.Blur.NORMAL)
         }
     }
 
-    val basePath = Path().apply {
-        when (outline) {
-            is Outline.Generic -> addPath(outline.path)
-            is Outline.Rectangle -> addRect(outline.rect)
-            is Outline.Rounded -> addRoundRect(outline.roundRect)
-        }
-    }
-
-    val clipPath = when (direction) {
-        ShadowDirection.BOTTOM -> Path().apply {
-            addRect(Rect(0f, 0f, size.width, size.height - blur.toPx()))
-        }
-        ShadowDirection.TOP -> Path().apply {
-            addRect(Rect(0f, blur.toPx(), size.width, size.height))
-        }
-        else -> null
-    }
-
-    val finalPath = if (clipPath != null) {
-        Path().apply { op(basePath, clipPath, PathOperation.Intersect) }
-    } else basePath
-
     drawIntoCanvas { canvas ->
         canvas.save()
         canvas.translate(offsetX.toPx(), offsetY.toPx())
-        if (direction == ShadowDirection.ALL) {
-            canvas.drawOutline(outline, paint)
-        } else {
-            canvas.drawPath(finalPath, paint)
-        }
+        canvas.drawOutline(shadowOutline, paint)
         canvas.restore()
     }
 }

--- a/core/designsystem/src/main/kotlin/com/pillsquad/yakssok/core/designsystem/util/ModifierExt.kt
+++ b/core/designsystem/src/main/kotlin/com/pillsquad/yakssok/core/designsystem/util/ModifierExt.kt
@@ -2,16 +2,24 @@ package com.pillsquad.yakssok.core.designsystem.util
 
 import android.graphics.BlurMaskFilter
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathOperation
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+
+enum class ShadowDirection { ALL, TOP, BOTTOM, START, END }
 
 fun Modifier.shadow(
     color: Color = Color.Black,
@@ -20,24 +28,48 @@ fun Modifier.shadow(
     offsetY: Dp = 0.dp,
     shape: Shape = RectangleShape,
     spread: Dp = 0.dp,
+    direction: ShadowDirection = ShadowDirection.ALL
 ) = this.drawBehind {
     val shadowSize = Size(size.width + spread.toPx(), size.height + spread.toPx())
-    val shadowOutline = shape.createOutline(shadowSize, layoutDirection, this)
+    val outline = shape.createOutline(shadowSize, layoutDirection, this)
 
-    val paint = Paint().apply {
-        this.color = color
-    }
-
+    val paint = Paint().apply { this.color = color }
     if (blur.toPx() > 0) {
         paint.asFrameworkPaint().apply {
             maskFilter = BlurMaskFilter(blur.toPx(), BlurMaskFilter.Blur.NORMAL)
         }
     }
 
+    val basePath = Path().apply {
+        when (outline) {
+            is Outline.Generic -> addPath(outline.path)
+            is Outline.Rectangle -> addRect(outline.rect)
+            is Outline.Rounded -> addRoundRect(outline.roundRect)
+        }
+    }
+
+    val clipPath = when (direction) {
+        ShadowDirection.BOTTOM -> Path().apply {
+            addRect(Rect(0f, 0f, size.width, size.height - blur.toPx()))
+        }
+        ShadowDirection.TOP -> Path().apply {
+            addRect(Rect(0f, blur.toPx(), size.width, size.height))
+        }
+        else -> null
+    }
+
+    val finalPath = if (clipPath != null) {
+        Path().apply { op(basePath, clipPath, PathOperation.Intersect) }
+    } else basePath
+
     drawIntoCanvas { canvas ->
         canvas.save()
         canvas.translate(offsetX.toPx(), offsetY.toPx())
-        canvas.drawOutline(shadowOutline, paint)
+        if (direction == ShadowDirection.ALL) {
+            canvas.drawOutline(outline, paint)
+        } else {
+            canvas.drawPath(finalPath, paint)
+        }
         canvas.restore()
     }
 }

--- a/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/component/DailyMedicineList.kt
+++ b/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/component/DailyMedicineList.kt
@@ -106,8 +106,9 @@ fun LazyItemScope.MedicineRowItem(
         finishedListener = {
             if (stage == 1) {
                 // 축소 끝 → 리스트 이동
-                onMoveRequest(routine)
                 scope.launch {
+                    delay(60)
+                    onMoveRequest(routine)
                     delay(240)
                     stage = 2
                 }

--- a/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/component/DailyMedicineList.kt
+++ b/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/component/DailyMedicineList.kt
@@ -1,8 +1,12 @@
 package com.pillsquad.yakssok.core.ui.component
 
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,15 +14,27 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -27,59 +43,129 @@ import com.pillsquad.yakssok.core.designsystem.theme.YakssokTheme
 import com.pillsquad.yakssok.core.model.Routine
 import com.pillsquad.yakssok.core.ui.R
 import com.pillsquad.yakssok.core.ui.ext.customInsets
+import kotlinx.datetime.LocalTime
 
-@Composable
-fun DailyMedicineList(
-    modifier: Modifier = Modifier,
+fun LazyListScope.dailyMedicineList(
     isCheckBoxVisible: Boolean = false,
-    routineList: List<Routine>,
+    haveToTake: List<Routine>,
+    taken: List<Routine>,
     onItemClick: (Int) -> Unit,
     onNavigateToRoute: () -> Unit
 ) {
-    val haveToTakeMedicineList = routineList.filter { !it.isTaken }
-    val takenMedicineList = routineList.filter { it.isTaken }
+    val rows = buildMedRows(haveToTake, taken) { it.intakeTime }
 
-    Column(
-        modifier = modifier
+    NestedScrollConnection
+
+    item {
+        TitleRow(
+            title = stringResource(R.string.have_to_take),
+            onNavigateToRoute = onNavigateToRoute
+        )
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(16.dp)
+                .background(YakssokTheme.color.grey50)
+        )
+    }
+
+    items(haveToTake, key = { it.routineId ?: it.hashCode() }) { medicine ->
+        MedicineRowItem(
+            routine = medicine,
+            isCheckBoxVisible = isCheckBoxVisible,
+            onMoveRequest = { medicine.routineId?.let { onItemClick(it) } }
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+
+    item {
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(12.dp)
+                .background(YakssokTheme.color.grey50)
+        )
+        TitleRow(stringResource(R.string.taked_medicine))
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(20.dp)
+                .background(YakssokTheme.color.grey50)
+        )
+    }
+
+    items(
+        items = taken,
+        key = { it.routineId ?: it.hashCode() }
+    ) { medicine ->
+        MedicineRowItem(
+            routine = medicine,
+            isCheckBoxVisible = isCheckBoxVisible,
+            onMoveRequest = { medicine.routineId?.let { onItemClick(it) } }
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun LazyItemScope.MedicineRowItem(
+    routine: Routine,
+    isCheckBoxVisible: Boolean,
+    onMoveRequest: (Routine) -> Unit
+) {
+    var stage by rememberSaveable { mutableIntStateOf(0) } // 0=정상, 1=축소중, 2=확대중
+    val scale by animateFloatAsState(
+        targetValue = when (stage) {
+            1 -> 0.8f   // 축소
+            2 -> 1.05f  // 팅! 커짐
+            else -> 1f
+        },
+        animationSpec = tween(if (stage == 1) 120 else 160),
+        finishedListener = {
+            if (stage == 1) {
+                // 축소 끝 → 리스트 이동
+                onMoveRequest(routine)
+                stage = 2
+            } else if (stage == 2) {
+                // 팅! 끝 → 원래 크기로 복귀
+                stage = 0
+            }
+        }
+    )
+
+    DailyMedicineRow(
+        modifier = Modifier
+            .animateItem()
+            .graphicsLayer(scaleX = scale, scaleY = scale)
+            .padding(horizontal = 16.dp),
+        isCheckBoxVisible = isCheckBoxVisible,
+        routine = routine,
+        onClick = { if (stage == 0) stage = 1 } // 축소 애니메이션 시작
+    )
+}
+
+@Composable
+private fun TitleRow(
+    title: String,
+    onNavigateToRoute: (() -> Unit)? = null
+) {
+    Row(
+        modifier = Modifier
             .fillMaxWidth()
             .background(YakssokTheme.color.grey50)
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = stringResource(R.string.have_to_take),
-                style = YakssokTheme.typography.body2,
-                color = YakssokTheme.color.grey600
-            )
-
-            AddButton(onClick = onNavigateToRoute)
-        }
-        Spacer(modifier = Modifier.height(16.dp))
-        haveToTakeMedicineList.forEach { medicine ->
-            DailyMedicineRow(
-                isCheckBoxVisible = isCheckBoxVisible,
-                routine = medicine,
-                onClick = { medicine.routineId?.let { onItemClick(it) } }
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-        }
-        Spacer(modifier = Modifier.height(12.dp))
         Text(
-            text = stringResource(R.string.taked_medicine),
+            text = title,
             style = YakssokTheme.typography.body2,
             color = YakssokTheme.color.grey600
         )
-        Spacer(modifier = Modifier.height(20.dp))
-        takenMedicineList.forEach { medicine ->
-            DailyMedicineRow(
-                isCheckBoxVisible = isCheckBoxVisible,
-                routine = medicine,
-                onClick = { medicine.routineId?.let { onItemClick(it) } }
-            )
-            Spacer(modifier = Modifier.height(8.dp))
+
+        onNavigateToRoute?.let {
+            AddButton(onClick = it)
         }
     }
 }
@@ -104,19 +190,38 @@ private fun AddButton(
     }
 }
 
+private sealed interface MedRow {
+    data class Header(val title: String, val id: String) : MedRow
+    data class Entry(val routine: Routine) : MedRow
+}
+
+private fun buildMedRows(
+    haveToTake: List<Routine>,
+    taken: List<Routine>,
+    timeKey: LocalTime
+): List<MedRow> {
+    val rows = mutableListOf<MedRow>()
+    rows += MedRow.Header("먹을 약", "HEADER_NOT_TAKEN")
+    rows += haveToTake.sortedBy(timeKey).map { MedRow.Entry(it) }
+    rows += MedRow.Header("복용 완료", "HEADER_TAKEN")
+    rows += taken.sortedBy(timeKey).map { MedRow.Entry(it) }
+    return rows
+}
+
 @Preview
 @Composable
 private fun DailyMedicineListPreview() {
     YakssokTheme {
-        Column(
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .background(YakssokTheme.color.grey50)
                 .customInsets(top = true, bottom = true)
                 .padding(16.dp)
         ) {
-            DailyMedicineList(
-                routineList = listOf(),
+            dailyMedicineList(
+                haveToTake = listOf(),
+                taken = listOf(),
                 onItemClick = {},
                 onNavigateToRoute = {}
             )

--- a/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/component/DailyMedicineList.kt
+++ b/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/component/DailyMedicineList.kt
@@ -1,7 +1,9 @@
 package com.pillsquad.yakssok.core.ui.component
 
 
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -23,10 +25,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -39,10 +43,13 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.pillsquad.yakssok.core.designsystem.theme.YakssokTheme
 import com.pillsquad.yakssok.core.model.Routine
 import com.pillsquad.yakssok.core.ui.R
 import com.pillsquad.yakssok.core.ui.ext.customInsets
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalTime
 
 fun LazyListScope.dailyMedicineList(
@@ -52,58 +59,31 @@ fun LazyListScope.dailyMedicineList(
     onItemClick: (Int) -> Unit,
     onNavigateToRoute: () -> Unit
 ) {
-    val rows = buildMedRows(haveToTake, taken) { it.intakeTime }
-
-    NestedScrollConnection
-
-    item {
-        TitleRow(
-            title = stringResource(R.string.have_to_take),
-            onNavigateToRoute = onNavigateToRoute
-        )
-        Spacer(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(16.dp)
-                .background(YakssokTheme.color.grey50)
-        )
-    }
-
-    items(haveToTake, key = { it.routineId ?: it.hashCode() }) { medicine ->
-        MedicineRowItem(
-            routine = medicine,
-            isCheckBoxVisible = isCheckBoxVisible,
-            onMoveRequest = { medicine.routineId?.let { onItemClick(it) } }
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-    }
-
-    item {
-        Spacer(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(12.dp)
-                .background(YakssokTheme.color.grey50)
-        )
-        TitleRow(stringResource(R.string.taked_medicine))
-        Spacer(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(20.dp)
-                .background(YakssokTheme.color.grey50)
-        )
-    }
+    val rows = buildMedRows(haveToTake, taken)
 
     items(
-        items = taken,
-        key = { it.routineId ?: it.hashCode() }
-    ) { medicine ->
-        MedicineRowItem(
-            routine = medicine,
-            isCheckBoxVisible = isCheckBoxVisible,
-            onMoveRequest = { medicine.routineId?.let { onItemClick(it) } }
-        )
-        Spacer(modifier = Modifier.height(8.dp))
+        items = rows,
+        key = {
+            when (it) {
+                is MedRow.Header -> it.id
+                is MedRow.Entry -> it.routine.routineId ?: it.hashCode()
+            }
+        }
+    ) { row ->
+        when (row) {
+            is MedRow.Header -> {
+                TitleRow(row.title, onNavigateToRoute)
+            }
+
+            is MedRow.Entry -> {
+                MedicineRowItem(
+                    routine = row.routine,
+                    isCheckBoxVisible = isCheckBoxVisible,
+                    onMoveRequest = { r -> r.routineId?.let(onItemClick) }
+                )
+                Spacer(Modifier.height(8.dp))
+            }
+        }
     }
 }
 
@@ -114,6 +94,7 @@ fun LazyItemScope.MedicineRowItem(
     isCheckBoxVisible: Boolean,
     onMoveRequest: (Routine) -> Unit
 ) {
+    val scope = rememberCoroutineScope()
     var stage by rememberSaveable { mutableIntStateOf(0) } // 0=정상, 1=축소중, 2=확대중
     val scale by animateFloatAsState(
         targetValue = when (stage) {
@@ -126,7 +107,10 @@ fun LazyItemScope.MedicineRowItem(
             if (stage == 1) {
                 // 축소 끝 → 리스트 이동
                 onMoveRequest(routine)
-                stage = 2
+                scope.launch {
+                    delay(240)
+                    stage = 2
+                }
             } else if (stage == 2) {
                 // 팅! 끝 → 원래 크기로 복귀
                 stage = 0
@@ -136,7 +120,13 @@ fun LazyItemScope.MedicineRowItem(
 
     DailyMedicineRow(
         modifier = Modifier
-            .animateItem()
+            .zIndex(if (stage == 1) 0f else 1f)
+            .animateItem(
+                placementSpec = spring(
+                    dampingRatio = Spring.DampingRatioLowBouncy,
+                    stiffness = Spring.StiffnessMedium
+                )
+            )
             .graphicsLayer(scaleX = scale, scaleY = scale)
             .padding(horizontal = 16.dp),
         isCheckBoxVisible = isCheckBoxVisible,
@@ -197,14 +187,13 @@ private sealed interface MedRow {
 
 private fun buildMedRows(
     haveToTake: List<Routine>,
-    taken: List<Routine>,
-    timeKey: LocalTime
+    taken: List<Routine>
 ): List<MedRow> {
     val rows = mutableListOf<MedRow>()
     rows += MedRow.Header("먹을 약", "HEADER_NOT_TAKEN")
-    rows += haveToTake.sortedBy(timeKey).map { MedRow.Entry(it) }
+    rows += haveToTake.sortedBy { it.intakeTime }.map { MedRow.Entry(it) }
     rows += MedRow.Header("복용 완료", "HEADER_TAKEN")
-    rows += taken.sortedBy(timeKey).map { MedRow.Entry(it) }
+    rows += taken.sortedBy { it.intakeTime }.map { MedRow.Entry(it) }
     return rows
 }
 

--- a/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/component/DailyMedicineRow.kt
+++ b/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/component/DailyMedicineRow.kt
@@ -38,6 +38,7 @@ import java.time.format.DateTimeFormatter
 
 @Composable
 fun DailyMedicineRow(
+    modifier: Modifier = Modifier,
     routine: Routine,
     isFeedback: Boolean = false,
     isCheckBoxVisible: Boolean = false,
@@ -61,7 +62,7 @@ fun DailyMedicineRow(
     val formattedTime = formatLocalTime(routine.intakeTime)
 
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .height(IntrinsicSize.Min)
             .defaultMinSize(minHeight = 56.dp)

--- a/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/component/NoMedicineColumn.kt
+++ b/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/component/NoMedicineColumn.kt
@@ -30,7 +30,7 @@ import com.pillsquad.yakssok.core.ui.R
 
 @Composable
 fun NoMedicineColumn(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     isNeverAlarm: Boolean,
     onNavigateToRoutine: () -> Unit
 ) {

--- a/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/CalendarScreen.kt
+++ b/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/CalendarScreen.kt
@@ -154,7 +154,6 @@ internal fun CalendarScreen(
                     (uiState.selectedUserIdx == 0) && (uiState.selectedDate == today)
 
                 dailyMedicineList(
-                    modifier = modifier,
                     isCheckBoxVisible = isCheckBoxVisible,
                     haveToTake = uiState.routineCache[uiState.selectedUserIdx]?.get(uiState.selectedDate)
                         ?: emptyList(),

--- a/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/CalendarScreen.kt
+++ b/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/CalendarScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.core.util.isEmpty
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pillsquad.yakssok.core.common.today
@@ -73,6 +72,7 @@ internal fun CalendarScreen(
 ) {
     val modifier = Modifier.padding(horizontal = 16.dp)
     val today = LocalDate.today()
+    val routineGroup = uiState.routineCache[uiState.selectedUserIdx]?.get(uiState.selectedDate)
 
     Column(
         modifier = Modifier
@@ -120,10 +120,6 @@ internal fun CalendarScreen(
             }
 
             item {
-                Spacer(modifier = Modifier.height(32.dp))
-            }
-
-            item {
                 Spacer(
                     modifier = Modifier
                         .height(8.dp)
@@ -137,15 +133,13 @@ internal fun CalendarScreen(
                 Spacer(modifier = Modifier.height(32.dp))
             }
 
-            item {
-
-            }
-
-            if (uiState.routineCache.isEmpty()) {
+            if (routineGroup == null || routineGroup.isEmpty()) {
+                val isNeverAlarm =
+                    uiState.userList.getOrNull(uiState.selectedUserIdx)?.isNotMedicine ?: false
                 item {
                     NoMedicineColumn(
                         modifier = modifier,
-                        isNeverAlarm = false,
+                        isNeverAlarm = isNeverAlarm,
                         onNavigateToRoutine = onNavigateRoutine
                     )
                 }
@@ -155,10 +149,8 @@ internal fun CalendarScreen(
 
                 dailyMedicineList(
                     isCheckBoxVisible = isCheckBoxVisible,
-                    haveToTake = uiState.routineCache[uiState.selectedUserIdx]?.get(uiState.selectedDate)
-                        ?: emptyList(),
-                    taken = uiState.routineCache[uiState.selectedUserIdx]?.get(uiState.selectedDate)
-                        ?: emptyList(),
+                    haveToTake = routineGroup.haveToTake,
+                    taken = routineGroup.taken,
                     onItemClick = onRoutineClick,
                     onNavigateToRoute = onNavigateRoutine
                 )

--- a/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/CalendarScreen.kt
+++ b/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/CalendarScreen.kt
@@ -18,9 +18,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pillsquad.yakssok.core.common.today
 import com.pillsquad.yakssok.core.designsystem.component.YakssokTopAppBar
 import com.pillsquad.yakssok.core.designsystem.theme.YakssokTheme
-import com.pillsquad.yakssok.core.ui.component.DailyMedicineList
 import com.pillsquad.yakssok.core.ui.component.MateLazyRow
 import com.pillsquad.yakssok.core.ui.component.NoMedicineColumn
+import com.pillsquad.yakssok.core.ui.component.dailyMedicineList
 import com.pillsquad.yakssok.core.ui.compositionlocal.LocalShowErrorSnackBar
 import com.pillsquad.yakssok.core.ui.ext.CollectEvent
 import com.pillsquad.yakssok.core.ui.ext.OnResumeEffect
@@ -138,25 +138,31 @@ internal fun CalendarScreen(
             }
 
             item {
-                if (uiState.routineCache.isEmpty()) {
+
+            }
+
+            if (uiState.routineCache.isEmpty()) {
+                item {
                     NoMedicineColumn(
                         modifier = modifier,
                         isNeverAlarm = false,
                         onNavigateToRoutine = onNavigateRoutine
                     )
-                } else {
-                    val isCheckBoxVisible =
-                        (uiState.selectedUserIdx == 0) && (uiState.selectedDate == today)
-
-                    DailyMedicineList(
-                        modifier = modifier,
-                        isCheckBoxVisible = isCheckBoxVisible,
-                        routineList = uiState.routineCache[uiState.selectedUserIdx]?.get(uiState.selectedDate)
-                            ?: emptyList(),
-                        onItemClick = onRoutineClick,
-                        onNavigateToRoute = onNavigateRoutine
-                    )
                 }
+            } else {
+                val isCheckBoxVisible =
+                    (uiState.selectedUserIdx == 0) && (uiState.selectedDate == today)
+
+                dailyMedicineList(
+                    modifier = modifier,
+                    isCheckBoxVisible = isCheckBoxVisible,
+                    haveToTake = uiState.routineCache[uiState.selectedUserIdx]?.get(uiState.selectedDate)
+                        ?: emptyList(),
+                    taken = uiState.routineCache[uiState.selectedUserIdx]?.get(uiState.selectedDate)
+                        ?: emptyList(),
+                    onItemClick = onRoutineClick,
+                    onNavigateToRoute = onNavigateRoutine
+                )
             }
 
             item {

--- a/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/CalendarViewModel.kt
+++ b/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/CalendarViewModel.kt
@@ -1,6 +1,5 @@
 package com.pillsquad.yakssok.feature.calendar
 
-import android.util.Log
 import android.util.SparseArray
 import androidx.core.util.size
 import androidx.lifecycle.ViewModel
@@ -13,6 +12,8 @@ import com.pillsquad.yakssok.core.model.UserCache
 import com.pillsquad.yakssok.feature.calendar.model.CalendarCacheManager
 import com.pillsquad.yakssok.feature.calendar.model.CalendarConfig
 import com.pillsquad.yakssok.feature.calendar.model.CalendarUiModel
+import com.pillsquad.yakssok.feature.calendar.model.toRoutineGroup
+import com.pillsquad.yakssok.feature.calendar.model.toRoutineList
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -69,11 +70,11 @@ class CalendarViewModel @Inject constructor(
 
         if (userIdx != 0 || date != today) return
 
-        val updated = currentMap[date]?.map {
+        val updated = currentMap[date]?.toRoutineList()?.map {
             if (it.routineId == routineId) it.copy(isTaken = !it.isTaken) else it
         } ?: return
 
-        val newUserMap = currentMap.toMutableMap().apply { put(date, updated) }
+        val newUserMap = currentMap.toMutableMap().apply { put(date, updated.toRoutineGroup()) }
         val newCache = uiState.value.routineCache.copyAndPut(userIdx, newUserMap)
 
         _uiState.update { it.copy(routineCache = newCache) }

--- a/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/model/CalendarCacheManager.kt
+++ b/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/model/CalendarCacheManager.kt
@@ -6,14 +6,14 @@ import com.pillsquad.yakssok.core.model.UserCache
 import kotlinx.datetime.LocalDate
 
 class CalendarCacheManager(
-    private val routineCache: SparseArray<MutableMap<LocalDate, List<Routine>>>,
+    private val routineCache: SparseArray<MutableMap<LocalDate, RoutineGroup>>,
     private val takenCache: SparseArray<MutableMap<LocalDate, Boolean>>
 ) {
 
     fun merge(userIdx: Int, cache: UserCache) {
         val currentRoutine = routineCache[userIdx] ?: mutableMapOf()
         val newRoutine = currentRoutine.toMutableMap().apply {
-            cache.routineCache.forEach { (date, list) -> this[date] = list }
+            cache.routineCache.forEach { (date, list) -> this[date] = list.toRoutineGroup() }
         }
         routineCache.put(userIdx, newRoutine)
 
@@ -26,7 +26,7 @@ class CalendarCacheManager(
 
     fun updateRoutine(userIdx: Int, date: LocalDate, routines: List<Routine>) {
         val routineMap = routineCache[userIdx] ?: mutableMapOf()
-        routineMap[date] = routines
+        routineMap[date] = routines.toRoutineGroup()
         routineCache.put(userIdx, routineMap)
 
         updateTaken(userIdx, date)
@@ -34,8 +34,8 @@ class CalendarCacheManager(
 
     fun updateTaken(userIdx: Int, date: LocalDate) {
         val routineMap = routineCache[userIdx] ?: return
-        val routineList = routineMap[date] ?: return
-        val allTaken = routineList.all { it.isTaken }
+        val routineGroup = routineMap[date] ?: return
+        val allTaken = !routineGroup.isEmpty() && routineGroup.haveToTake.isEmpty()
 
         val takenMap = takenCache[userIdx] ?: mutableMapOf()
         takenMap[date] = allTaken

--- a/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/model/CalendarUiModel.kt
+++ b/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/model/CalendarUiModel.kt
@@ -11,7 +11,7 @@ data class CalendarUiModel(
     val selectedDate: LocalDate = LocalDate.today(),
     val userList: List<User> = listOf(),
     // userId to <먹을 날짜, 먹어야 하는 약 리스트>
-    val routineCache: SparseArray<MutableMap<LocalDate, List<Routine>>> = SparseArray(),
+    val routineCache: SparseArray<MutableMap<LocalDate, RoutineGroup>> = SparseArray(),
     // userId to <먹을 날짜, 그 날짜에 약 다 먹었는가?>
     val takenCache: SparseArray<MutableMap<LocalDate, Boolean>> = SparseArray()
 )

--- a/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/model/RoutineGroup.kt
+++ b/feature/calendar/src/main/kotlin/com/pillsquad/yakssok/feature/calendar/model/RoutineGroup.kt
@@ -1,0 +1,17 @@
+package com.pillsquad.yakssok.feature.calendar.model
+
+import com.pillsquad.yakssok.core.model.Routine
+
+data class RoutineGroup(
+    val haveToTake: List<Routine>,
+    val taken: List<Routine>
+) {
+    fun isEmpty(): Boolean = haveToTake.isEmpty() && taken.isEmpty()
+}
+
+fun List<Routine>.toRoutineGroup(): RoutineGroup {
+    val (haveToTake, taken) =  this.partition { !it.isTaken }
+    return RoutineGroup(haveToTake, taken)
+}
+
+fun RoutineGroup.toRoutineList(): List<Routine> = this.haveToTake + this.taken

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeScreen.kt
@@ -9,10 +9,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
@@ -33,14 +32,15 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pillsquad.yakssok.core.common.today
 import com.pillsquad.yakssok.core.designsystem.component.YakssokTopAppBar
 import com.pillsquad.yakssok.core.designsystem.theme.YakssokTheme
+import com.pillsquad.yakssok.core.designsystem.util.ShadowDirection
 import com.pillsquad.yakssok.core.designsystem.util.shadow
 import com.pillsquad.yakssok.core.model.FeedbackTarget
-import com.pillsquad.yakssok.core.model.Routine
+import com.pillsquad.yakssok.core.model.FeedbackType
 import com.pillsquad.yakssok.core.model.User
-import com.pillsquad.yakssok.core.ui.component.DailyMedicineList
 import com.pillsquad.yakssok.core.ui.component.MateLazyRow
 import com.pillsquad.yakssok.core.ui.component.NoMedicineColumn
 import com.pillsquad.yakssok.core.ui.component.PullToRefreshColumn
+import com.pillsquad.yakssok.core.ui.component.dailyMedicineList
 import com.pillsquad.yakssok.core.ui.compositionlocal.LocalShowErrorSnackBar
 import com.pillsquad.yakssok.core.ui.ext.CollectEvent
 import com.pillsquad.yakssok.core.ui.ext.OnResumeEffect
@@ -49,6 +49,7 @@ import com.pillsquad.yakssok.feature.home.component.RemindDialog
 import com.pillsquad.yakssok.feature.home.component.UserInfoCard
 import com.pillsquad.yakssok.feature.home.component.WeekDataSelector
 import com.pillsquad.yakssok.feature.home.model.HomeUiState
+import com.pillsquad.yakssok.feature.home.model.RoutineGroup
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.minus
@@ -152,37 +153,76 @@ private fun HomeScreen(
     onNavigateRoutine: () -> Unit,
     onNavigateCalendar: () -> Unit,
 ) {
-    val scrollState = rememberScrollState()
     val showFeedbackSection by remember(state.feedbackTargetList) {
         derivedStateOf { state.feedbackTargetList.isNotEmpty() }
     }
 
-    Column(
+    val routineGroup = state.routineCache[state.selectedUserIdx]?.get(state.selectedDate)
+    val today = LocalDate.today()
+
+    LazyColumn(
         modifier = Modifier
             .fillMaxWidth()
-            .background(YakssokTheme.color.grey100)
-            .verticalScroll(scrollState)
+            .background(YakssokTheme.color.grey50)
     ) {
-        if (showFeedbackSection) {
-            FeedbackSection(
-                feedbackTargetList = state.feedbackTargetList,
-                onClickFeedback = onClickFeedback
+        if (true) {
+            item {
+                FeedbackSection(
+                    feedbackTargetList = listOf(
+                        FeedbackTarget(
+                            userId = 1,
+                            nickName = "인우마스터",
+                            profileImageUrl = "",
+                            feedbackType = FeedbackType.NAG,
+                            routineCount = 1,
+                            routineList = emptyList()
+                        )
+                    ),
+                    onClickFeedback = onClickFeedback
+                )
+            }
+        }
+
+        item {
+            HomeContent(
+                userProfileList = state.userList,
+                routineCache = state.routineCache,
+                selectedDate = state.selectedDate,
+                selectedUserIdx = state.selectedUserIdx,
+                isRounded = true,
+                onClickUser = onClickUser,
+                onSelectDate = onSelectDate,
+                onClickRoutine = onClickRoutine,
+                onNavigateMate = onNavigateMate,
+                onNavigateRoutine = onNavigateRoutine,
+                onNavigateCalendar = onNavigateCalendar
             )
         }
 
-        HomeContent(
-            userProfileList = state.userList,
-            routineCache = state.routineCache,
-            selectedDate = state.selectedDate,
-            selectedUserIdx = state.selectedUserIdx,
-            isRounded = showFeedbackSection,
-            onClickUser = onClickUser,
-            onSelectDate = onSelectDate,
-            onClickRoutine = onClickRoutine,
-            onNavigateMate = onNavigateMate,
-            onNavigateRoutine = onNavigateRoutine,
-            onNavigateCalendar = onNavigateCalendar
-        )
+        if (routineGroup == null || routineGroup.isEmpty()) {
+            val isNeverAlarm =
+                state.userList.getOrNull(state.selectedUserIdx)?.isNotMedicine ?: false
+            item {
+                NoMedicineColumn(
+                    isNeverAlarm = isNeverAlarm,
+                    onNavigateToRoutine = onNavigateRoutine
+                )
+            }
+        } else {
+            val isCheckBoxVisible = (state.selectedUserIdx == 0) && (state.selectedDate == today)
+            dailyMedicineList(
+                haveToTake = routineGroup.haveToTake,
+                taken = routineGroup.taken,
+                isCheckBoxVisible = isCheckBoxVisible,
+                onItemClick = onClickRoutine,
+                onNavigateToRoute = onNavigateRoutine
+            )
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
     }
 }
 
@@ -191,9 +231,10 @@ private fun FeedbackSection(
     feedbackTargetList: List<FeedbackTarget>,
     onClickFeedback: (FeedbackTarget) -> Unit
 ) {
-    Spacer(modifier = Modifier.height(16.dp))
     LazyRow(
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(YakssokTheme.color.grey100)
     ) {
         item { Spacer(modifier = Modifier.width(16.dp)) }
 
@@ -208,13 +249,26 @@ private fun FeedbackSection(
             Spacer(modifier = Modifier.width(16.dp))
         }
     }
-    Spacer(modifier = Modifier.height(16.dp))
+    Spacer(modifier = Modifier
+        .background(YakssokTheme.color.grey100)
+        .fillMaxWidth()
+        .height(22.dp)
+        .shadow(
+            offsetX = 0.dp,
+            offsetY = 4.dp,
+            blur = 12.dp,
+            color = Color.Black.copy(alpha = 0.15f),
+            direction = ShadowDirection.BOTTOM
+        )
+        .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+        .background(YakssokTheme.color.grey50)
+    )
 }
 
 @Composable
 private fun HomeContent(
     userProfileList: List<User>,
-    routineCache: SparseArray<MutableMap<LocalDate, List<Routine>>>,
+    routineCache: SparseArray<MutableMap<LocalDate, RoutineGroup>>,
     selectedDate: LocalDate,
     selectedUserIdx: Int,
     isRounded: Boolean,
@@ -230,24 +284,12 @@ private fun HomeContent(
     val topPadding = if (isRounded) 32.dp else 10.dp
 
     val today = LocalDate.today()
-    val weekDates by remember {
-        derivedStateOf { calculateCurrentWeek(today) }
-    }
-
-    val selectedUser = userProfileList.getOrNull(selectedUserIdx) ?: return
-    val routineList = routineCache[selectedUserIdx]?.get(selectedDate) ?: emptyList()
+    val weekDates by remember { derivedStateOf { calculateCurrentWeek(today) } }
 
     Column(
         modifier = Modifier
-            .shadow(
-                offsetX = 0.dp,
-                offsetY = 4.dp,
-                blur = 12.dp,
-                color = Color.Black.copy(alpha = 0.15f),
-            )
-            .clip(shape)
-            .background(YakssokTheme.color.grey50)
-            .padding(top = topPadding, start = 16.dp, end = 16.dp),
+            .padding(top = 10.dp, start = 16.dp, end = 16.dp)
+            .background(YakssokTheme.color.grey50),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         MateLazyRow(
@@ -264,22 +306,6 @@ private fun HomeContent(
             onNavigateCalendar = onNavigateCalendar
         )
         Spacer(modifier = Modifier.height(32.dp))
-
-        if (routineList.isEmpty()) {
-            NoMedicineColumn(
-                isNeverAlarm = selectedUser.isNotMedicine,
-                onNavigateToRoutine = onNavigateRoutine
-            )
-        } else {
-            val isCheckBoxVisible = (selectedUserIdx == 0) && (selectedDate == today)
-            DailyMedicineList(
-                routineList = routineList,
-                isCheckBoxVisible = isCheckBoxVisible,
-                onItemClick = onClickRoutine,
-                onNavigateToRoute = onNavigateRoutine
-            )
-        }
-        Spacer(modifier = Modifier.height(16.dp))
     }
 }
 

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeScreen.kt
@@ -1,9 +1,7 @@
 package com.pillsquad.yakssok.feature.home
 
 import android.util.SparseArray
-import android.widget.Toast
 import androidx.compose.animation.core.LinearOutSlowInEasing
-import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -16,10 +14,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.pulltorefresh.PullToRefreshState
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,7 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -54,7 +51,6 @@ import com.pillsquad.yakssok.feature.home.component.WeekDataSelector
 import com.pillsquad.yakssok.feature.home.model.HomeUiState
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.isoDayNumber
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 
@@ -69,11 +65,10 @@ internal fun HomeRoute(
     onNavigateCalendar: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-
     val showSnackbar = LocalShowErrorSnackBar.current
-    val scrollState = rememberScrollState()
-    val refreshState = rememberPullToRefreshState()
+    var feedbackTarget by remember { mutableStateOf<FeedbackTarget?>(null) }
 
+    val refreshState = rememberPullToRefreshState()
     var isRefreshing by remember { mutableStateOf(false) }
 
     val scaleFraction = {
@@ -85,8 +80,6 @@ internal fun HomeRoute(
         isRefreshing = true
         viewModel.refresh()
     }
-
-    var feedbackTarget by remember { mutableStateOf<FeedbackTarget?>(null) }
 
     OnResumeEffect { viewModel.refresh() }
     CollectEvent(viewModel.errorFlow) { showSnackbar(it) }
@@ -108,87 +101,6 @@ internal fun HomeRoute(
         )
     }
 
-    when (val state = uiState) {
-        HomeUiState.Loading -> {
-            PullToRefreshColumn(
-                refreshState = refreshState,
-                isRefreshing = isRefreshing,
-                scaleFraction = scaleFraction,
-                onRefresh = onRefresh,
-                topBar = {
-                    YakssokTopAppBar(
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                        isLogo = true,
-                        onNavigateAlert = onNavigateAlert,
-                        onNavigateMy = onNavigateMyPage
-                    )
-                }
-            ) {
-                HomeSkeleton(showFeedbackSection = true)
-            }
-        }
-
-        is HomeUiState.Success -> {
-            if (state.remindList.isNotEmpty()) {
-                val nickName = state.userList[0].nickName
-
-                RemindDialog(
-                    name = nickName,
-                    routineList = state.remindList,
-                    onDismiss = { viewModel.clearRemindState() }
-                )
-            }
-
-            HomeScreen(
-                isRefreshing = isRefreshing,
-                scaleFraction = scaleFraction,
-                refreshState = refreshState,
-                showFeedBackSection = state.feedbackTargetList.isNotEmpty(),
-                selectedDate = state.selectedDate,
-                userProfileList = state.userList,
-                feedbackTargetList = state.feedbackTargetList,
-                routineCache = state.routineCache,
-                selectedUserIdx = state.selectedUserIdx,
-                scrollState = scrollState,
-                onRefresh = onRefresh,
-                onClickUser = viewModel::onMateClick,
-                onSelectDate = viewModel::onSelectedDate,
-                onClickRoutine = viewModel::onRoutineClick,
-                onClickFeedback = { feedbackTarget = it },
-                onNavigateMy = onNavigateMyPage,
-                onNavigateMate = onNavigateMate,
-                onNavigateAlert = onNavigateAlert,
-                onNavigateRoutine = onNavigateRoutine,
-                onNavigateCalendar = onNavigateCalendar
-            )
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun HomeScreen(
-    isRefreshing: Boolean = false,
-    scaleFraction: () -> Float = { 1f },
-    refreshState: PullToRefreshState = rememberPullToRefreshState(),
-    showFeedBackSection: Boolean = false,
-    selectedDate: LocalDate = LocalDate.today(),
-    userProfileList: List<User> = emptyList(),
-    feedbackTargetList: List<FeedbackTarget> = emptyList(),
-    routineCache: SparseArray<MutableMap<LocalDate, List<Routine>>> = SparseArray(),
-    selectedUserIdx: Int = 0,
-    scrollState: ScrollState = rememberScrollState(),
-    onRefresh: () -> Unit = {},
-    onClickUser: (Int) -> Unit = {},
-    onSelectDate: (LocalDate) -> Unit = {},
-    onClickRoutine: (Int) -> Unit = {},
-    onClickFeedback: (FeedbackTarget) -> Unit = {},
-    onNavigateMy: () -> Unit = {},
-    onNavigateMate: () -> Unit = {},
-    onNavigateAlert: () -> Unit = {},
-    onNavigateRoutine: () -> Unit = {},
-    onNavigateCalendar: () -> Unit = {},
-) {
     PullToRefreshColumn(
         refreshState = refreshState,
         isRefreshing = isRefreshing,
@@ -199,90 +111,134 @@ private fun HomeScreen(
                 modifier = Modifier.padding(horizontal = 16.dp),
                 isLogo = true,
                 onNavigateAlert = onNavigateAlert,
-                onNavigateMy = onNavigateMy
+                onNavigateMy = onNavigateMyPage
             )
         }
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(YakssokTheme.color.grey100)
-                .verticalScroll(scrollState)
-        ) {
-
-
-            if (showFeedBackSection) {
-                Spacer(modifier = Modifier.height(16.dp))
-
-                LazyRow(
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    item { Spacer(modifier = Modifier.width(16.dp)) }
-
-                    items(feedbackTargetList.size) { index ->
-                        val feedbackTarget = feedbackTargetList[index]
-
-                        UserInfoCard(
-                            feedback = feedbackTarget,
-                            onClick = { onClickFeedback(feedbackTarget) }
-                        )
-
-                        Spacer(modifier = Modifier.width(16.dp))
-                    }
-
+        when (val state = uiState) {
+            is HomeUiState.Loading -> HomeSkeleton(showFeedbackSection = true)
+            is HomeUiState.Success -> {
+                state.remindList.firstOrNull()?.let {
+                    RemindDialog(
+                        name = state.userList.firstOrNull()?.nickName.orEmpty(),
+                        routineList = state.remindList,
+                        onDismiss = viewModel::clearRemindState
+                    )
                 }
 
-                Spacer(modifier = Modifier.height(16.dp))
+                HomeScreen(
+                    state = state,
+                    onClickUser = viewModel::onMateClick,
+                    onSelectDate = viewModel::onSelectedDate,
+                    onClickRoutine = viewModel::onRoutineClick,
+                    onClickFeedback = { feedbackTarget = it },
+                    onNavigateMate = onNavigateMate,
+                    onNavigateRoutine = onNavigateRoutine,
+                    onNavigateCalendar = onNavigateCalendar
+                )
             }
-
-            HomeContent(
-                modifier = Modifier,
-                userProfileList = userProfileList,
-                routineList = routineCache[selectedUserIdx]?.get(selectedDate) ?: emptyList(),
-                selectedDate = selectedDate,
-                selectedUserIdx = selectedUserIdx,
-                isRounded = showFeedBackSection,
-                isNotMedicine = userProfileList[selectedUserIdx].isNotMedicine,
-                onClickUser = onClickUser,
-                onSelectDate = onSelectDate,
-                onClickRoutine = onClickRoutine,
-                onNavigateMate = onNavigateMate,
-                onNavigateRoutine = onNavigateRoutine,
-                onNavigateCalendar = onNavigateCalendar
-            )
         }
     }
 }
 
 @Composable
-private fun HomeContent(
-    modifier: Modifier,
-    userProfileList: List<User>,
-    routineList: List<Routine>,
-    selectedDate: LocalDate,
-    selectedUserIdx: Int,
-    isRounded: Boolean,
-    isNotMedicine: Boolean,
+private fun HomeScreen(
+    state: HomeUiState.Success,
     onClickUser: (Int) -> Unit,
-    onSelectDate: (LocalDate) -> Unit = {},
-    onClickRoutine: (Int) -> Unit = {},
+    onSelectDate: (LocalDate) -> Unit,
+    onClickRoutine: (Int) -> Unit,
+    onClickFeedback: (FeedbackTarget) -> Unit,
     onNavigateMate: () -> Unit,
     onNavigateRoutine: () -> Unit,
     onNavigateCalendar: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    val showFeedbackSection by remember(state.feedbackTargetList) {
+        derivedStateOf { state.feedbackTargetList.isNotEmpty() }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(YakssokTheme.color.grey100)
+            .verticalScroll(scrollState)
+    ) {
+        if (showFeedbackSection) {
+            FeedbackSection(
+                feedbackTargetList = state.feedbackTargetList,
+                onClickFeedback = onClickFeedback
+            )
+        }
+
+        HomeContent(
+            userProfileList = state.userList,
+            routineCache = state.routineCache,
+            selectedDate = state.selectedDate,
+            selectedUserIdx = state.selectedUserIdx,
+            isRounded = showFeedbackSection,
+            onClickUser = onClickUser,
+            onSelectDate = onSelectDate,
+            onClickRoutine = onClickRoutine,
+            onNavigateMate = onNavigateMate,
+            onNavigateRoutine = onNavigateRoutine,
+            onNavigateCalendar = onNavigateCalendar
+        )
+    }
+}
+
+@Composable
+private fun FeedbackSection(
+    feedbackTargetList: List<FeedbackTarget>,
+    onClickFeedback: (FeedbackTarget) -> Unit
+) {
+    Spacer(modifier = Modifier.height(16.dp))
+    LazyRow(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        item { Spacer(modifier = Modifier.width(16.dp)) }
+
+        items(feedbackTargetList.size) { index ->
+            val feedbackTarget = feedbackTargetList[index]
+
+            UserInfoCard(
+                feedback = feedbackTarget,
+                onClick = { onClickFeedback(feedbackTarget) }
+            )
+
+            Spacer(modifier = Modifier.width(16.dp))
+        }
+    }
+    Spacer(modifier = Modifier.height(16.dp))
+}
+
+@Composable
+private fun HomeContent(
+    userProfileList: List<User>,
+    routineCache: SparseArray<MutableMap<LocalDate, List<Routine>>>,
+    selectedDate: LocalDate,
+    selectedUserIdx: Int,
+    isRounded: Boolean,
+    onClickUser: (Int) -> Unit,
+    onSelectDate: (LocalDate) -> Unit,
+    onClickRoutine: (Int) -> Unit,
+    onNavigateMate: () -> Unit,
+    onNavigateRoutine: () -> Unit,
+    onNavigateCalendar: () -> Unit
 ) {
     val shape =
         if (isRounded) RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp) else RectangleShape
     val topPadding = if (isRounded) 32.dp else 10.dp
 
     val today = LocalDate.today()
-    val weekDates = remember {
-        val currentDayOfWeek = today.dayOfWeek.isoDayNumber
-        val monday = today.minus(currentDayOfWeek - 1, DateTimeUnit.DAY)
-        (0..6).map { monday.plus(it, DateTimeUnit.DAY) }
+    val weekDates by remember {
+        derivedStateOf { calculateCurrentWeek(today) }
     }
 
+    val selectedUser = userProfileList.getOrNull(selectedUserIdx) ?: return
+    val routineList = routineCache[selectedUserIdx]?.get(selectedDate) ?: emptyList()
+
     Column(
-        modifier = modifier
+        modifier = Modifier
             .shadow(
                 offsetX = 0.dp,
                 offsetY = 4.dp,
@@ -298,7 +254,7 @@ private fun HomeContent(
             userList = userProfileList,
             selectedUserIdx = selectedUserIdx,
             onNavigateMate = onNavigateMate,
-            onMateClick = { onClickUser(it) }
+            onMateClick = onClickUser
         )
         Spacer(modifier = Modifier.height(8.dp))
         WeekDataSelector(
@@ -308,15 +264,14 @@ private fun HomeContent(
             onNavigateCalendar = onNavigateCalendar
         )
         Spacer(modifier = Modifier.height(32.dp))
+
         if (routineList.isEmpty()) {
             NoMedicineColumn(
-                modifier = Modifier,
-                isNeverAlarm = isNotMedicine,
+                isNeverAlarm = selectedUser.isNotMedicine,
                 onNavigateToRoutine = onNavigateRoutine
             )
         } else {
             val isCheckBoxVisible = (selectedUserIdx == 0) && (selectedDate == today)
-
             DailyMedicineList(
                 routineList = routineList,
                 isCheckBoxVisible = isCheckBoxVisible,
@@ -326,4 +281,9 @@ private fun HomeContent(
         }
         Spacer(modifier = Modifier.height(16.dp))
     }
+}
+
+private fun calculateCurrentWeek(today: LocalDate): List<LocalDate> {
+    val monday = today.minus(today.dayOfWeek.ordinal.toLong(), DateTimeUnit.DAY)
+    return List(7) { i -> monday.plus(i.toLong(), DateTimeUnit.DAY) }
 }

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeScreen.kt
@@ -3,6 +3,7 @@ package com.pillsquad.yakssok.feature.home
 import android.util.SparseArray
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -32,7 +33,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pillsquad.yakssok.core.common.today
 import com.pillsquad.yakssok.core.designsystem.component.YakssokTopAppBar
 import com.pillsquad.yakssok.core.designsystem.theme.YakssokTheme
-import com.pillsquad.yakssok.core.designsystem.util.ShadowDirection
 import com.pillsquad.yakssok.core.designsystem.util.shadow
 import com.pillsquad.yakssok.core.model.FeedbackTarget
 import com.pillsquad.yakssok.core.model.FeedbackType
@@ -165,19 +165,10 @@ private fun HomeScreen(
             .fillMaxWidth()
             .background(YakssokTheme.color.grey50)
     ) {
-        if (true) {
+        if (showFeedbackSection) {
             item {
                 FeedbackSection(
-                    feedbackTargetList = listOf(
-                        FeedbackTarget(
-                            userId = 1,
-                            nickName = "인우마스터",
-                            profileImageUrl = "",
-                            feedbackType = FeedbackType.NAG,
-                            routineCount = 1,
-                            routineList = emptyList()
-                        )
-                    ),
+                    feedbackTargetList = state.feedbackTargetList,
                     onClickFeedback = onClickFeedback
                 )
             }
@@ -186,15 +177,12 @@ private fun HomeScreen(
         item {
             HomeContent(
                 userProfileList = state.userList,
-                routineCache = state.routineCache,
                 selectedDate = state.selectedDate,
                 selectedUserIdx = state.selectedUserIdx,
-                isRounded = true,
+                isRounded = showFeedbackSection,
                 onClickUser = onClickUser,
                 onSelectDate = onSelectDate,
-                onClickRoutine = onClickRoutine,
                 onNavigateMate = onNavigateMate,
-                onNavigateRoutine = onNavigateRoutine,
                 onNavigateCalendar = onNavigateCalendar
             )
         }
@@ -219,10 +207,7 @@ private fun HomeScreen(
             )
         }
 
-        item {
-            Spacer(modifier = Modifier.height(16.dp))
-        }
-
+        item { Spacer(modifier = Modifier.height(16.dp)) }
     }
 }
 
@@ -249,34 +234,17 @@ private fun FeedbackSection(
             Spacer(modifier = Modifier.width(16.dp))
         }
     }
-    Spacer(modifier = Modifier
-        .background(YakssokTheme.color.grey100)
-        .fillMaxWidth()
-        .height(22.dp)
-        .shadow(
-            offsetX = 0.dp,
-            offsetY = 4.dp,
-            blur = 12.dp,
-            color = Color.Black.copy(alpha = 0.15f),
-            direction = ShadowDirection.BOTTOM
-        )
-        .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
-        .background(YakssokTheme.color.grey50)
-    )
 }
 
 @Composable
 private fun HomeContent(
     userProfileList: List<User>,
-    routineCache: SparseArray<MutableMap<LocalDate, RoutineGroup>>,
     selectedDate: LocalDate,
     selectedUserIdx: Int,
     isRounded: Boolean,
     onClickUser: (Int) -> Unit,
     onSelectDate: (LocalDate) -> Unit,
-    onClickRoutine: (Int) -> Unit,
     onNavigateMate: () -> Unit,
-    onNavigateRoutine: () -> Unit,
     onNavigateCalendar: () -> Unit
 ) {
     val shape =
@@ -286,26 +254,41 @@ private fun HomeContent(
     val today = LocalDate.today()
     val weekDates by remember { derivedStateOf { calculateCurrentWeek(today) } }
 
-    Column(
-        modifier = Modifier
-            .padding(top = 10.dp, start = 16.dp, end = 16.dp)
-            .background(YakssokTheme.color.grey50),
-        horizontalAlignment = Alignment.CenterHorizontally
+    Box(
+        modifier = Modifier.fillMaxWidth()
     ) {
-        MateLazyRow(
-            userList = userProfileList,
-            selectedUserIdx = selectedUserIdx,
-            onNavigateMate = onNavigateMate,
-            onMateClick = onClickUser
+        Spacer(modifier = Modifier
+            .background(YakssokTheme.color.grey100)
+            .matchParentSize()
+            .shadow(
+                color = Color.Black.copy(alpha = 0.15f),
+                blur = 12.dp,
+                offsetY = 4.dp,
+                shape = shape
+            )
         )
-        Spacer(modifier = Modifier.height(8.dp))
-        WeekDataSelector(
-            weekDates = weekDates,
-            selectedDate = selectedDate,
-            onDateSelected = onSelectDate,
-            onNavigateCalendar = onNavigateCalendar
-        )
-        Spacer(modifier = Modifier.height(32.dp))
+        Column(
+            modifier = Modifier
+                .clip(shape)
+                .background(YakssokTheme.color.grey50)
+                .padding(top = topPadding, start = 16.dp, end = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            MateLazyRow(
+                userList = userProfileList,
+                selectedUserIdx = selectedUserIdx,
+                onNavigateMate = onNavigateMate,
+                onMateClick = onClickUser
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            WeekDataSelector(
+                weekDates = weekDates,
+                selectedDate = selectedDate,
+                onDateSelected = onSelectDate,
+                onNavigateCalendar = onNavigateCalendar
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+        }
     }
 }
 

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeViewModel.kt
@@ -11,10 +11,12 @@ import com.pillsquad.yakssok.core.domain.usecase.GetUserProfileListUseCase
 import com.pillsquad.yakssok.core.domain.usecase.GetUserRoutineUseCase
 import com.pillsquad.yakssok.core.domain.usecase.PostFeedbackUseCase
 import com.pillsquad.yakssok.core.domain.usecase.UpdateRoutineTakenUseCase
-import com.pillsquad.yakssok.core.model.Routine
 import com.pillsquad.yakssok.core.model.User
 import com.pillsquad.yakssok.core.model.UserCache
 import com.pillsquad.yakssok.feature.home.model.HomeUiState
+import com.pillsquad.yakssok.feature.home.model.RoutineGroup
+import com.pillsquad.yakssok.feature.home.model.toRoutineGroup
+import com.pillsquad.yakssok.feature.home.model.toRoutineList
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -23,8 +25,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
@@ -94,7 +94,8 @@ class HomeViewModel @Inject constructor(
             val targets = targetsDef.await()
 
             val adjustedUsers = recomputeIsNotMedicine(users, cache)
-            val todayRemind = cache[0]?.get(today).orEmpty().filter { it.isFeedbackRoutine(now) }
+            val todayRemind =
+                cache[0]?.get(today)?.haveToTake?.filter { it.isFeedbackRoutine(now) }.orEmpty()
             val shouldShowRemind = (previous?.isInit ?: true) && todayRemind.isNotEmpty()
 
             HomeUiState.Success(
@@ -129,11 +130,11 @@ class HomeViewModel @Inject constructor(
         if (userIdx != 0 || date != today) return
 
         val currentMap = state.routineCache[userIdx] ?: return
-        val updated = currentMap[date]?.map {
+        val updated = currentMap[date]?.toRoutineList()?.map {
             if (it.routineId == routineId) it.copy(isTaken = !it.isTaken) else it
         } ?: return
 
-        val newUserMap = currentMap.toMutableMap().apply { put(date, updated) }
+        val newUserMap = currentMap.toMutableMap().apply { put(date, updated.toRoutineGroup()) }
         val newCache = state.routineCache.copyAndPut(userIdx, newUserMap)
 
         _uiState.value = state.copy(routineCache = newCache)
@@ -170,16 +171,18 @@ class HomeViewModel @Inject constructor(
         users: List<User>,
         startDate: LocalDate,
         endDate: LocalDate
-    ): SparseArray<MutableMap<LocalDate, List<Routine>>> {
-        var acc = SparseArray<MutableMap<LocalDate, List<Routine>>>()
+    ): SparseArray<MutableMap<LocalDate, RoutineGroup>> {
+        var acc = SparseArray<MutableMap<LocalDate, RoutineGroup>>()
 
         val my = fetchRoutineOrEmpty(userId = null, startDate, endDate)
-        acc = acc.copyAndPut(0, my.routineCache)
+            .routineCache.mapValues { (_, list) -> list.toRoutineGroup() }.toMutableMap()
+        acc = acc.copyAndPut(0, my)
 
         users.drop(1).forEach { friend ->
             val cache = fetchRoutineOrEmpty(friend.id, startDate, endDate)
+                .routineCache.mapValues { (_, list) -> list.toRoutineGroup() }.toMutableMap()
             val userIdx = users.indexOfFirst { it.id == friend.id }
-            if (userIdx != -1) acc = acc.copyAndPut(userIdx, cache.routineCache)
+            if (userIdx != -1) acc = acc.copyAndPut(userIdx, cache)
         }
         return acc
     }
@@ -206,10 +209,12 @@ class HomeViewModel @Inject constructor(
 
     private fun recomputeIsNotMedicine(
         users: List<User>,
-        cache: SparseArray<MutableMap<LocalDate, List<Routine>>>
+        cache: SparseArray<MutableMap<LocalDate, RoutineGroup>>
     ): List<User> {
         return users.mapIndexed { idx, user ->
-            val hasAny = cache[idx]?.values?.any { it.isNotEmpty() } == true
+            val hasAny = cache[idx]?.values?.any {
+                it.haveToTake.isNotEmpty() || it.taken.isNotEmpty()
+            } == true
             user.copy(isNotMedicine = !hasAny)
         }
     }

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/component/UserInfoCard.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/component/UserInfoCard.kt
@@ -39,6 +39,7 @@ internal fun UserInfoCard(
 
     Column(
         modifier = Modifier
+            .padding(vertical = 16.dp)
             .shadow(
                 offsetX = 0.dp,
                 offsetY = 4.dp,
@@ -55,17 +56,13 @@ internal fun UserInfoCard(
             modifier = Modifier.size(52.dp),
             imageUrl = feedback.profileImageUrl,
         )
-
         Spacer(modifier = Modifier.height(8.dp))
-
         Text(
             text = feedback.nickName,
             style = YakssokTheme.typography.subtitle2,
             color = YakssokTheme.color.grey600
         )
-
         Spacer(modifier = Modifier.height(4.dp))
-
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -98,9 +95,7 @@ internal fun UserInfoCard(
                 )
             }
         }
-
         Spacer(modifier = Modifier.height(4.dp))
-
         if (isNagging) {
             YakssokButton(
                 modifier = Modifier.height(40.dp),

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/model/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/model/HomeUiState.kt
@@ -21,7 +21,7 @@ sealed interface HomeUiState {
             )
         ),
         val feedbackTargetList: List<FeedbackTarget> = emptyList(),
-        val routineCache: SparseArray<MutableMap<LocalDate, List<Routine>>> = SparseArray(),
+        val routineCache: SparseArray<MutableMap<LocalDate, RoutineGroup>> = SparseArray(),
         val remindList: List<Routine> = emptyList()
     ) : HomeUiState
 }

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/model/RoutineGroup.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/model/RoutineGroup.kt
@@ -1,0 +1,17 @@
+package com.pillsquad.yakssok.feature.home.model
+
+import com.pillsquad.yakssok.core.model.Routine
+
+data class RoutineGroup(
+    val haveToTake: List<Routine>,
+    val taken: List<Routine>
+) {
+    fun isEmpty(): Boolean = haveToTake.isEmpty() && taken.isEmpty()
+}
+
+fun List<Routine>.toRoutineGroup(): RoutineGroup {
+    val (haveToTake, taken) =  this.partition { !it.isTaken }
+    return RoutineGroup(haveToTake, taken)
+}
+
+fun RoutineGroup.toRoutineList(): List<Routine> = this.haveToTake + this.taken


### PR DESCRIPTION
# What?

![image.png](attachment:c99c9ed5-cef5-49bf-bc28-cf9e2f65fc31:image.png)

Home, Calendar에서 복약 리스트의 복약 상태가 변경이 될 때마다 이동이 되는 애니메니션을 적용해야한다.

지켜야 하는 사항은 아래와 같다.

1. 복약 버튼을 클릭하면 크기가 줄어든다.
2. 크기가 줄어든 이후에 이동을 한다.
    1. 이동할 때는 모든 뷰의 밑으로 이동한다.(다른 뷰들을 가리지 않도록)
    2. 복약 순서에 따라서 정렬이 된 형태로 이동이 완료되어야 한다.
3. 이동이 완료되면 다시 커진다.

# How?

현재 화면 구성에서는 위의 기능이 어렵거나 비효율적이다.

- 코드
    
    ```kotlin
    @Composable
    private fun HomeScreen(...) {
        val scrollState = rememberScrollState()
        val showFeedbackSection by remember(state.feedbackTargetList) {
            derivedStateOf { state.feedbackTargetList.isNotEmpty() }
        }
    
        Column(
            modifier = Modifier
                .fillMaxWidth()
                .background(YakssokTheme.color.grey100)
                .verticalScroll(scrollState)
        ) {
            if (showFeedbackSection) {
                FeedbackSection(
                    feedbackTargetList = state.feedbackTargetList,
                    onClickFeedback = onClickFeedback
                )
            }
    
            HomeContent(...)
        }
    }
    
    @Composable
    private fun HomeContent(...) {
        // 중략
    
        Column(
            modifier = Modifier
                .shadow(
                    offsetX = 0.dp,
                    offsetY = 4.dp,
                    blur = 12.dp,
                    color = Color.Black.copy(alpha = 0.15f),
                )
                .clip(shape)
                .background(YakssokTheme.color.grey50)
                .padding(top = topPadding, start = 16.dp, end = 16.dp),
            horizontalAlignment = Alignment.CenterHorizontally
        ) {
            // 중략
    
            if (routineList.isEmpty()) {
                NoMedicineColumn(
                    isNeverAlarm = selectedUser.isNotMedicine,
                    onNavigateToRoutine = onNavigateRoutine
                )
            } else {
                val isCheckBoxVisible = (selectedUserIdx == 0) && (selectedDate == today)
                DailyMedicineList(
                    routineList = routineList,
                    isCheckBoxVisible = isCheckBoxVisible,
                    onItemClick = onClickRoutine,
                    onNavigateToRoute = onNavigateRoutine
                )
            }
            Spacer(modifier = Modifier.height(16.dp))
        }
    }
    
    @Composable
    fun DailyMedicineList(...) {
        val haveToTakeMedicineList = routineList.filter { !it.isTaken }
        val takenMedicineList = routineList.filter { it.isTaken }
    
        Column(
            modifier = modifier
                .fillMaxWidth()
                .background(YakssokTheme.color.grey50)
        ) {
            // 중략
            haveToTakeMedicineList.forEach { medicine ->
                DailyMedicineRow(
                    isCheckBoxVisible = isCheckBoxVisible,
                    routine = medicine,
                    onClick = { medicine.routineId?.let { onItemClick(it) } }
                )
                Spacer(modifier = Modifier.height(8.dp))
            }
            // 중략
        }
    }
    
    ```
    

화면 구성이 TopBar를 제외하고 모두 스크롤이 적용되어야 하기 때문에 가장 상단에 VerticalScroll을 적용하고 목록들은 forEach를 사용하여 그려주고 있다.

목록에서 아이템을 이동하는 애니메이션인 `animtaeItem()` 을 사용하기 위해서는 LazyColumn을 사용해야 하는데, DailyMedicineList 부분에 LazyColumn을 적용하면 NestedScroll 충돌이 발생한다.

따라서 전체를 LazyColumn으로 적용을 하던가, 중첩 스크롤을 할 수 있는 방법을 고안해야 했다.

### 방법 1 - NestedScrollConnection

안드로이드 오픈 채팅방에서 부모 스크롤과 자식 스크롤을 동시에 사용하기 위한 방법으로 NestedScrollConnection에 대해서 언급이 된 적이 있기에 이를 찾아봤다.

여러 스크롤 가능한 컴포넌트가 있을 때, 부모와 자식 스크롤 동작을 이어주는 역할을 하며, 자식이 스크롤 이벤트를 받을 때, 부모에게 사전/사후 단계로 알려주고, 부모가 일부를 소비할 수 있도록 한다.

이를 이용하여 HomeScreen 전체에 새로 스크롤을 두고, DailyMedicineList를 별도 LazyColumn으로 만들고 nestedScroll(connection)으로 부모와 연결하여 스크롤이 자연스럽게 이어지면 DailyMedicineList가 부모의 배경을 따라갈 수 있을 것이라는 기대를 했다.

실제로 구현했을때 각 스크롤이 별도로 존재하며, 이는 DailyMedicineList가 정해진 높이를 가졌을때 스크롤의 우선순위를 정하는데 더 유용하다는 것을 알게 되었다.

이 해결방법은 현 상태에서 유용하지 않다는 것을 깨달았다.

### 방법 2 - 전체 LazyColumn

결국 HomeScreen을 LazyColumn으로 변경하고 하위의 아이템들을 Item, Items로 적용하는 방법을 생각했다.

하지만 이 방법을 적용하면서도 문제점이 많이 존재했다.

기존에 DailyMedicineList가 HomeContent의 하위 컴포넌트로 HomeContent의 배경을 따라갔는데, DailyMedicineList에 있는 목록들이 items로 적용하면서 HomeContent와 DailyMedicineList를 분리해야 하는 상황이 발생했다.

이를 해결하기 위하여 컴포넌트의 배치를 변경하고, 배경색 적용의 위치들을 다양하게 적용했고, 결국 각 item에 해당하는 컴포넌트에 디자인에 맞는 padding과 배경색들을 각각 적용해야 한다는 것을 알게 되었다.

![image.png](attachment:8fa76fd1-ead6-4e0a-9142-f790584dcbd2:image.png)

하지만 프로필 리스트(+버튼이 존재하는 곳) 상단에 roundRect와 그에 적용된 shadow 때문에 item들을 나열하면 HomeContent의 하단 부분에도 shadow가 적용이 되어 DailyMedicineList에 해당하는 부분들과 HomeContent 부분이 분리되어 보인다는 문제점이 발생했다.

처음에는 Shadow를 위에만 적용하려고 했지만, 결국 어떤 방식을 적용해도 하단에 조금은 보인다는 것일 확인했다.

```kotlin
Box(
      modifier = Modifier.fillMaxWidth()
  ) {
      Spacer(modifier = Modifier
          .background(YakssokTheme.color.grey100)
          .matchParentSize()
          .shadow(
              color = Color.Black.copy(alpha = 0.15f),
              blur = 12.dp,
              offsetY = 4.dp,
              shape = shape
          )
      )
      Column(
          modifier = Modifier
              .clip(shape)
              .background(YakssokTheme.color.grey50)
              .padding(top = topPadding, start = 16.dp, end = 16.dp),
          horizontalAlignment = Alignment.CenterHorizontally
      ) {
          // 중략
      }
  }
```

이를 해결하기 위해서 HomeContent에 Box를 두고 피드백 섹션이 드러날 때는 Spacer에 적용한 그림자가 드러나며, 하단 부분은 Column이 덮어 보이지 않도록 구현했다.

### 애니메이션 적용

LazyList에서 아이템 목록 변경에서 아이템을 적용하기 위해서 ChatGPT와 Gemini에게 코드 변경을 요청했을때, `animateItemPlacement()` 를 사용하고 있었는데, 이는 deprecated 되었으며 `animateItem()` 이 모든 기능을 대신한다는 것을 알게 되었다.

```kotlin
fun LazyListScope.dailyMedicineList(
    isCheckBoxVisible: Boolean = false,
    haveToTake: List<Routine>,
    taken: List<Routine>,
    onItemClick: (Int) -> Unit,
    onNavigateToRoute: () -> Unit
) {
    val rows = buildMedRows(haveToTake, taken)

    items(
        items = rows,
        key = {
            when (it) {
                is MedRow.Header -> it.id
                is MedRow.Entry -> it.routine.routineId ?: it.hashCode()
            }
        }
    ) { row ->
        when (row) {
            is MedRow.Header -> {
                TitleRow(row.title, onNavigateToRoute)
            }

            is MedRow.Entry -> {
                MedicineRowItem(
                    routine = row.routine,
                    isCheckBoxVisible = isCheckBoxVisible,
                    onMoveRequest = { r -> r.routineId?.let(onItemClick) }
                )
                Spacer(Modifier.height(8.dp))
            }
        }
    }
}

@OptIn(ExperimentalFoundationApi::class)
@Composable
fun LazyItemScope.MedicineRowItem(
    routine: Routine,
    isCheckBoxVisible: Boolean,
    onMoveRequest: (Routine) -> Unit
) {
    val scope = rememberCoroutineScope()
    var stage by rememberSaveable { mutableIntStateOf(0) } // 0=정상, 1=축소중, 2=확대중
    val scale by animateFloatAsState(
        targetValue = when (stage) {
            1 -> 0.8f   // 축소
            2 -> 1.05f  // 팅! 커짐
            else -> 1f
        },
        animationSpec = tween(if (stage == 1) 120 else 160),
        finishedListener = {
            if (stage == 1) {
                // 축소 끝 → 리스트 이동
                onMoveRequest(routine)
                scope.launch {
                    delay(240)
                    stage = 2
                }
            } else if (stage == 2) {
                // 팅! 끝 → 원래 크기로 복귀
                stage = 0
            }
        }
    )

    DailyMedicineRow(
        modifier = Modifier
            .zIndex(if (stage == 1) 0f else 1f)
            .animateItem(
                placementSpec = spring(
                    dampingRatio = Spring.DampingRatioLowBouncy,
                    stiffness = Spring.StiffnessMedium
                )
            )
            .graphicsLayer(scaleX = scale, scaleY = scale)
            .padding(horizontal = 16.dp),
        isCheckBoxVisible = isCheckBoxVisible,
        routine = routine,
        onClick = { if (stage == 0) stage = 1 } // 축소 애니메이션 시작
    )
}

private sealed interface MedRow {
    data class Header(val title: String, val id: String) : MedRow
    data class Entry(val routine: Routine) : MedRow
}

private fun buildMedRows(
    haveToTake: List<Routine>,
    taken: List<Routine>
): List<MedRow> {
    val rows = mutableListOf<MedRow>()
    rows += MedRow.Header("먹을 약", "HEADER_NOT_TAKEN")
    rows += haveToTake.sortedBy { it.intakeTime }.map { MedRow.Entry(it) }
    rows += MedRow.Header("복용 완료", "HEADER_TAKEN")
    rows += taken.sortedBy { it.intakeTime }.map { MedRow.Entry(it) }
    return rows
}
```

상위 HomeScreen의 LazyColumn이니 DailyMedicineList를 LazyListScope의 확장함수로 만들고 진행했다.

자연스러운 아이템 변화를 위하여 List<MedRow>를 만들고, 아이템 변화가 생길때 key를 통해서 이를 확인하여 이동시키도록 구현했다.

애니메이션은 3단계로 나누었고, 자연스러운 애니메이션 구성을 위하여 dampingRatio와 stiffness의 다양한 옵션들을 테스트하며 디자인에 맞는 옵션을 찾았다.

마지막으로 이동이 끝난 뒤에 다시 커지는 효과를 주기 위하여 이동을 시킬 때는 coroutine의 delay로 대기 시간을 두고, 대기 시간 이후에 다시 커지도록 구현했다.