### PR TITLE
[YSA-75/Home] 홈 화면 튜토리얼 애니메이션 적용

### DIFF
--- a/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/ext/ModifierExt.kt
+++ b/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/ext/ModifierExt.kt
@@ -49,14 +49,3 @@ fun Modifier.yakssokDefault(color: Color): Modifier {
         .padding(horizontal = 16.dp)
         .padding(bottom = 16.dp)
 }
-
-fun getAlignmentByLocation(loc: Location): Alignment {
-    return when (loc) {
-        Location.TOP_START -> Alignment.TopStart
-        Location.TOP_END -> Alignment.TopEnd
-        Location.TOP_CENTER -> Alignment.TopCenter
-        Location.BOTTOM_START -> Alignment.BottomStart
-        Location.BOTTOM_END -> Alignment.BottomEnd
-        Location.BOTTOM_CENTER -> Alignment.BottomCenter
-    }
-}

--- a/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/model/TutorialTargetKey.kt
+++ b/core/ui/src/main/kotlin/com/pillsquad/yakssok/core/ui/model/TutorialTargetKey.kt
@@ -1,6 +1,7 @@
 package com.pillsquad.yakssok.core.ui.model
 
 import androidx.annotation.StringRes
+import androidx.compose.ui.Alignment
 import com.pillsquad.yakssok.core.ui.R
 
 enum class TutorialTargetKey(val loc: Location, val textGroupRes: ExplainTextGroupRes) {
@@ -67,11 +68,36 @@ enum class TutorialTargetKey(val loc: Location, val textGroupRes: ExplainTextGro
             R.string.empty,
             R.string.empty
         )
-    )
+    );
+
+    companion object {
+        private val hiddenExplainKeys = setOf(
+            EMPTY,
+            NOTIFICATION,
+            END
+        )
+
+        fun TutorialTargetKey.shouldHideExplain(): Boolean =
+            this in hiddenExplainKeys
+
+        fun TutorialTargetKey.isNotificationKey(): Boolean =
+            this == NOTIFICATION || this == NOTIFICATION_COMPLETE
+
+        fun TutorialTargetKey.shouldHideOverlay(): Boolean =
+            this == EMPTY || this == END
+    }
 }
 
-enum class Location {
-    TOP_START, TOP_END, TOP_CENTER, BOTTOM_START, BOTTOM_END, BOTTOM_CENTER
+enum class Location(
+    val alignment: Alignment
+) {
+    TOP_START(Alignment.TopStart),
+    TOP_END(Alignment.TopEnd),
+    TOP_CENTER(Alignment.TopCenter),
+    BOTTOM_START(Alignment.BottomStart),
+    BOTTOM_END(Alignment.BottomEnd),
+    BOTTOM_CENTER(Alignment.BottomCenter);
+    fun isTop(): Boolean = this == TOP_START || this == TOP_END || this == TOP_CENTER
 }
 
 data class ExplainTextGroupRes(

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeScreen.kt
@@ -168,7 +168,11 @@ internal fun HomeRoute(
             onNavigateCalendar = {
                 viewModel.onIntent(HomeIntent.NavigateToCalendar)
             },
-            onMeasure = { key, rect -> rectMap[key] = rect }
+            onMeasure = { key, rect ->
+                if (!rectMap.containsKey(key)) {
+                    rectMap[key] = rect
+                }
+            }
         )
     }
 }

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeViewModel.kt
@@ -197,14 +197,12 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun nextTutorialStep() {
-        val newStep = (currentState.tutorialStep + 1) % 7
+        val newStep = currentState.tutorialStep + 1
         intent { copy(tutorialStep = newStep) }
         updateTutorialTarget(newStep)
     }
 
     private fun updateTutorialTarget(step: Int) {
-        step.debugLog("updateTutorialTarget")
-
         if (step in autoSteps) {
             runAutoAdvance()
         }

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/HomeViewModel.kt
@@ -197,12 +197,14 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun nextTutorialStep() {
-        val newStep = currentState.tutorialStep + 1
+        val newStep = (currentState.tutorialStep + 1) % 7
         intent { copy(tutorialStep = newStep) }
         updateTutorialTarget(newStep)
     }
 
     private fun updateTutorialTarget(step: Int) {
+        step.debugLog("updateTutorialTarget")
+
         if (step in autoSteps) {
             runAutoAdvance()
         }

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/component/TutorialColumn.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/component/TutorialColumn.kt
@@ -1,5 +1,10 @@
 package com.pillsquad.yakssok.feature.home.component
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector4D
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.TwoWayConverter
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -19,18 +24,20 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshState
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathFillType
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -54,10 +61,20 @@ import com.pillsquad.yakssok.core.ui.ext.toRect
 import com.pillsquad.yakssok.core.ui.model.TutorialTargetKey
 import com.pillsquad.yakssok.core.ui.model.TutorialTargetKey.Companion.isNotificationKey
 import com.pillsquad.yakssok.core.ui.model.TutorialTargetKey.Companion.shouldHideExplain
-import com.pillsquad.yakssok.core.ui.model.TutorialTargetKey.Companion.shouldHideOverlay
 import com.pillsquad.yakssok.feature.home.HomeSkeleton
 import com.pillsquad.yakssok.feature.home.R
 import com.pillsquad.yakssok.feature.home.model.HomeState
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private val RectVectorConverter = TwoWayConverter<Rect, AnimationVector4D>(
+    convertToVector = { rect ->
+        AnimationVector4D(rect.left, rect.top, rect.right, rect.bottom)
+    },
+    convertFromVector = { vector ->
+        Rect(vector.v1, vector.v2, vector.v3, vector.v4)
+    }
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -77,26 +94,121 @@ internal fun TutorialColumn(
     val density = LocalDensity.current
     val screenHeightPx = LocalWindowInfo.current.containerSize.height
 
-    var explainRect by remember { mutableStateOf<Rect?>(null) }
+    val rectAnim = remember {
+        Animatable(
+            initialValue = Rect(0f, 0f, 0f, 0f),
+            typeConverter = RectVectorConverter
+        )
+    }
+    val overlayAlphaAnim = remember { Animatable(0.7f) }
+    val explainAlphaAnim = remember { Animatable(0f) }
 
-    val textTopDp = remember(highlightRect, density) {
-        highlightRect?.let { with(density) { it.bottom.toDp() } + 24.dp } ?: 24.dp
+    var previousStep by remember { mutableIntStateOf(state.tutorialStep) }
+    var previousHighlight by remember { mutableStateOf<Rect?>(null) }
+
+    var isVisible by remember(highlightRect) { mutableStateOf(false) }
+
+    val animatedHighlight: Rect? = remember(highlightRect, rectAnim.value) {
+        if (highlightRect == null) {
+            null
+        } else {
+            val current = rectAnim.value
+            if (current.width == 0f && current.height == 0f) {
+                // 애니메이션 최초 실행 전에는 highlightRect를 그대로 사용
+                highlightRect
+            } else {
+                current
+            }
+        }
     }
 
-    val textBottomDp = remember(highlightRect, density, screenHeightPx) {
+    // step에 따른 overlayAlpha, explainAlpha, highlightRect 애니메이션 처리
+    LaunchedEffect(state.tutorialStep) {
+        val fromStep = previousStep
+        val toStep = state.tutorialStep
+        val fromRect = previousHighlight
+        val toRect = highlightRect
+
+        // overlayAlpha 애니메이션 (2→3, 3→4, 4→5, 5→6 포함 전체 step 대응)
+        val targetAlpha = when (state.currentTargetKey) {
+            TutorialTargetKey.EMPTY,
+            TutorialTargetKey.END -> 0f
+
+            TutorialTargetKey.NOTIFICATION -> 0.3f
+            TutorialTargetKey.NOTIFICATION_COMPLETE -> 0.7f
+
+            else -> 0.7f
+        }
+
+        val isMovingHighlightStep =
+            (fromStep == 0 && toStep == 1 || fromStep == 1 && toStep == 2) && fromRect != null && toRect != null
+
+        val highlightDuration = 700
+
+        launch {
+            explainAlphaAnim.snapTo(0f)
+
+            isVisible = true
+
+            when (toStep) {
+                0 -> explainAlphaAnim.snapTo(1f)
+
+                4, 6 -> {
+                    explainAlphaAnim.animateTo(
+                        targetValue = 1f,
+                        animationSpec = tween(durationMillis = 250)
+                    )
+                }
+
+                else -> {
+
+                    delay((highlightDuration * 0.9).toLong())
+                    explainAlphaAnim.animateTo(
+                        targetValue = 1f,
+                        animationSpec = tween(durationMillis = 250)
+                    )
+                }
+            }
+        }
+
+        launch {
+            overlayAlphaAnim.animateTo(
+                targetValue = targetAlpha,
+                animationSpec = tween(durationMillis = 300)
+            )
+        }
+
+        if (isMovingHighlightStep) {
+            // Rect 이동 애니메이션
+            launch {
+                rectAnim.animateTo(
+                    targetValue = toRect,
+                    animationSpec = tween(
+                        durationMillis = highlightDuration,
+                        easing = LinearOutSlowInEasing
+                    )
+                )
+            }
+        } else {
+            // Rect 이동 애니메이션이 필요 없는 경우: 그냥 스냅
+            rectAnim.snapTo(toRect ?: Rect(0f, 0f, 0f, 0f))
+        }
+
+        previousStep = toStep
+        previousHighlight = toRect
+    }
+
+    val textTopDp = remember(highlightRect) {
+        highlightRect?.let {
+            with(density) { it.bottom.toDp() } + 24.dp
+        } ?: 24.dp
+    }
+
+    val textBottomDp = remember(highlightRect) {
         highlightRect?.let {
             with(density) { screenHeightPx.toDp() - it.top.toDp() } + 24.dp
         } ?: 24.dp
     }
-
-    val explainTopDp = remember(explainRect, textTopDp, density) {
-        explainRect?.let { with(density) { it.bottom.toDp() + 20.dp } } ?: textTopDp
-    }
-
-    val isExplainVisible = !state.currentTargetKey.shouldHideExplain() && highlightRect != null
-    val isNotificationVisible = state.currentTargetKey.isNotificationKey()
-    val hideOverlay = state.currentTargetKey.shouldHideOverlay()
-    val overlayAlpha = if (state.currentTargetKey == TutorialTargetKey.NOTIFICATION) 0.3f else 0.7f
 
     Box(modifier = Modifier.fillMaxSize()) {
         MainContent(
@@ -114,48 +226,49 @@ internal fun TutorialColumn(
         if (!state.isTutorialComplete) {
             TutorialOverlay(
                 density = density,
-                isOverlay = !hideOverlay,
-                overlayAlaph = overlayAlpha,
-                highlightRect = highlightRect,
+                overlayAlaph = overlayAlphaAnim.value,
+                highlightRect = animatedHighlight,
                 onClickNextStep = onClickNextStep
             )
 
-            if (isExplainVisible) {
-                ExplainText(
+            if (!state.currentTargetKey.shouldHideExplain() && isVisible) {
+                Column(
                     modifier = Modifier
-                        .align(state.currentTargetKey.loc.alignment)
-                        .padding(
-                            start = 32.dp,
-                            top = if (state.currentTargetKey.loc.isTop()) textTopDp else 0.dp,
-                            end = 32.dp,
-                            bottom = if (!state.currentTargetKey.loc.isTop()) textBottomDp else 0.dp
+                        .align(state.currentTargetKey.loc.alignment),
+                    verticalArrangement = Arrangement.spacedBy(20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    ExplainText(
+                        modifier = Modifier
+                            .padding(
+                                start = 32.dp,
+                                top = if (state.currentTargetKey.loc.isTop()) textTopDp else 0.dp,
+                                end = 32.dp,
+                                bottom = if (!state.currentTargetKey.loc.isTop()) textBottomDp else 0.dp
+                            )
+                            .alpha(explainAlphaAnim.value),
+                        firstContent = stringResource(state.currentTargetKey.textGroupRes.firstContent),
+                        highlightContent = stringResource(state.currentTargetKey.textGroupRes.highlightContent),
+                        secondContent = stringResource(state.currentTargetKey.textGroupRes.secondContent)
+                    )
+
+                    if (state.currentTargetKey == TutorialTargetKey.NOTIFICATION_COMPLETE) {
+                        YakssokButton(
+                            modifier = Modifier
+                                .padding(horizontal = 72.dp)
+                                .alpha(explainAlphaAnim.value),
+                            text = stringResource(R.string.tutorial_button),
+                            contentColor = YakssokTheme.color.grey50,
+                            onClick = onClickNextStep
                         )
-                        .onGloballyPositioned {
-                            explainRect = it.toRect(density)
-                        },
-                    firstContent = stringResource(state.currentTargetKey.textGroupRes.firstContent),
-                    highlightContent = stringResource(state.currentTargetKey.textGroupRes.highlightContent),
-                    secondContent = stringResource(state.currentTargetKey.textGroupRes.secondContent)
-                )
+                    }
+                }
             }
 
-            if (isNotificationVisible) {
+            if (state.currentTargetKey.isNotificationKey()) {
                 ExampleNotification(
                     density = density,
                     onMeasure = onMeasure
-                )
-            }
-
-            if (state.currentTargetKey == TutorialTargetKey.NOTIFICATION_COMPLETE) {
-                YakssokButton(
-                    modifier = Modifier.padding(
-                        start = 72.dp,
-                        end = 72.dp,
-                        top = explainTopDp,
-                    ),
-                    text = stringResource(R.string.tutorial_button),
-                    contentColor = YakssokTheme.color.grey50,
-                    onClick = onClickNextStep
                 )
             }
         }
@@ -197,17 +310,12 @@ private fun MainContent(
 @Composable
 private fun TutorialOverlay(
     density: Density,
-    isOverlay: Boolean = true,
     overlayAlaph: Float = 0.7f,
     highlightRect: Rect?,
     onClickNextStep: () -> Unit
 ) {
     val overlayRadius = 16.dp.toPx(density)
-    val overlayColor = if (isOverlay) {
-        YakssokTheme.color.black.copy(alpha = overlayAlaph)
-    } else {
-        Color.Transparent
-    }
+    val overlayColor = YakssokTheme.color.black.copy(alpha = overlayAlaph)
 
     val interactionSource = remember { MutableInteractionSource() }
 
@@ -263,7 +371,9 @@ private fun ExplainText(
         modifier = modifier
             .clip(RoundedCornerShape(12.dp))
             .background(YakssokTheme.color.grey900)
-            .padding(10.dp), text = annotatedText, style = YakssokTheme.typography.body1
+            .padding(10.dp),
+        text = annotatedText,
+        style = YakssokTheme.typography.body1
     )
 }
 
@@ -279,7 +389,7 @@ private fun ExampleNotification(
             .onGloballyPositioned {
                 onMeasure(it.toRect(density))
             }
-            .clip(RoundedCornerShape(21.dp))
+            .clip(RoundedCornerShape(16.dp))
             .background(YakssokTheme.color.grey150)
             .padding(start = 9.dp, end = 14.dp, top = 17.dp, bottom = 17.dp)
     ) {

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/component/TutorialColumn.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/component/TutorialColumn.kt
@@ -49,11 +49,12 @@ import com.pillsquad.yakssok.core.designsystem.component.YakssokImage
 import com.pillsquad.yakssok.core.designsystem.component.YakssokTopAppBar
 import com.pillsquad.yakssok.core.designsystem.theme.YakssokTheme
 import com.pillsquad.yakssok.core.ui.component.PullToRefreshColumn
-import com.pillsquad.yakssok.core.ui.ext.getAlignmentByLocation
 import com.pillsquad.yakssok.core.ui.ext.toPx
 import com.pillsquad.yakssok.core.ui.ext.toRect
-import com.pillsquad.yakssok.core.ui.model.Location
 import com.pillsquad.yakssok.core.ui.model.TutorialTargetKey
+import com.pillsquad.yakssok.core.ui.model.TutorialTargetKey.Companion.isNotificationKey
+import com.pillsquad.yakssok.core.ui.model.TutorialTargetKey.Companion.shouldHideExplain
+import com.pillsquad.yakssok.core.ui.model.TutorialTargetKey.Companion.shouldHideOverlay
 import com.pillsquad.yakssok.feature.home.HomeSkeleton
 import com.pillsquad.yakssok.feature.home.R
 import com.pillsquad.yakssok.feature.home.model.HomeState
@@ -122,12 +123,12 @@ internal fun TutorialColumn(
             if (isExplainVisible) {
                 ExplainText(
                     modifier = Modifier
-                        .align(getAlignmentByLocation(state.currentTargetKey.loc))
+                        .align(state.currentTargetKey.loc.alignment)
                         .padding(
                             start = 32.dp,
-                            top = if (state.currentTargetKey.loc.isTop) textTopDp else 0.dp,
+                            top = if (state.currentTargetKey.loc.isTop()) textTopDp else 0.dp,
                             end = 32.dp,
-                            bottom = if (!state.currentTargetKey.loc.isTop) textBottomDp else 0.dp
+                            bottom = if (!state.currentTargetKey.loc.isTop()) textBottomDp else 0.dp
                         )
                         .onGloballyPositioned {
                             explainRect = it.toRect(density)
@@ -318,21 +319,3 @@ private fun NotificationContent() {
         )
     }
 }
-
-private val Location.isTop: Boolean
-    get() = this == Location.TOP_START || this == Location.TOP_END || this == Location.TOP_CENTER
-
-private val hiddenExplainKeys = setOf(
-    TutorialTargetKey.NOTIFICATION,
-    TutorialTargetKey.EMPTY,
-    TutorialTargetKey.END
-)
-
-private fun TutorialTargetKey.shouldHideExplain(): Boolean =
-    this in hiddenExplainKeys
-
-private fun TutorialTargetKey.isNotificationKey(): Boolean =
-    this == TutorialTargetKey.NOTIFICATION || this == TutorialTargetKey.NOTIFICATION_COMPLETE
-
-private fun TutorialTargetKey.shouldHideOverlay(): Boolean =
-    this == TutorialTargetKey.EMPTY || this == TutorialTargetKey.END

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/component/TutorialColumn.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/component/TutorialColumn.kt
@@ -1,11 +1,7 @@
 package com.pillsquad.yakssok.feature.home.component
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.AnimationVector4D
 import androidx.compose.animation.core.LinearOutSlowInEasing
-import androidx.compose.animation.core.TwoWayConverter
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -32,16 +28,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.RoundRect
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
@@ -50,7 +45,6 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.toSize
 import com.pillsquad.yakssok.core.designsystem.component.YakssokButton
 import com.pillsquad.yakssok.core.designsystem.component.YakssokImage
 import com.pillsquad.yakssok.core.designsystem.component.YakssokTopAppBar
@@ -63,22 +57,20 @@ import com.pillsquad.yakssok.core.ui.model.TutorialTargetKey.Companion.isNotific
 import com.pillsquad.yakssok.core.ui.model.TutorialTargetKey.Companion.shouldHideExplain
 import com.pillsquad.yakssok.feature.home.HomeSkeleton
 import com.pillsquad.yakssok.feature.home.R
+import com.pillsquad.yakssok.feature.home.model.FADE_DURATION
+import com.pillsquad.yakssok.feature.home.model.HIGHLIGHT_DURATION
 import com.pillsquad.yakssok.feature.home.model.HomeState
+import com.pillsquad.yakssok.feature.home.model.OVERLAY_ALPHA_DIM
+import com.pillsquad.yakssok.feature.home.model.OVERLAY_ALPHA_FULL
+import com.pillsquad.yakssok.feature.home.model.OVERLAY_FADE_DURATION
+import com.pillsquad.yakssok.feature.home.model.TutorialTransitionState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-
-private val RectVectorConverter = TwoWayConverter<Rect, AnimationVector4D>(
-    convertToVector = { rect ->
-        AnimationVector4D(rect.left, rect.top, rect.right, rect.bottom)
-    },
-    convertFromVector = { vector ->
-        Rect(vector.v1, vector.v2, vector.v3, vector.v4)
-    }
-)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun TutorialColumn(
+    modifier: Modifier = Modifier,
     state: HomeState,
     highlightRect: Rect? = null,
     refreshState: PullToRefreshState = rememberPullToRefreshState(),
@@ -94,109 +86,16 @@ internal fun TutorialColumn(
     val density = LocalDensity.current
     val screenHeightPx = LocalWindowInfo.current.containerSize.height
 
-    val rectAnim = remember {
-        Animatable(
-            initialValue = Rect(0f, 0f, 0f, 0f),
-            typeConverter = RectVectorConverter
-        )
-    }
-    val overlayAlphaAnim = remember { Animatable(0.7f) }
-    val explainAlphaAnim = remember { Animatable(0f) }
+    var isExplainVisible by remember(highlightRect) { mutableStateOf(false) }
 
-    var previousStep by remember { mutableIntStateOf(state.tutorialStep) }
-    var previousHighlight by remember { mutableStateOf<Rect?>(null) }
+    val transitionState = rememberTutorialTransitionState(
+        tutorialStep = state.tutorialStep,
+        currentTargetKey = state.currentTargetKey,
+        highlightRect = highlightRect,
+        changeExplainVisible = { isExplainVisible = true }
+    )
 
-    var isVisible by remember(highlightRect) { mutableStateOf(false) }
-
-    val animatedHighlight: Rect? = remember(highlightRect, rectAnim.value) {
-        if (highlightRect == null) {
-            null
-        } else {
-            val current = rectAnim.value
-            if (current.width == 0f && current.height == 0f) {
-                // 애니메이션 최초 실행 전에는 highlightRect를 그대로 사용
-                highlightRect
-            } else {
-                current
-            }
-        }
-    }
-
-    // step에 따른 overlayAlpha, explainAlpha, highlightRect 애니메이션 처리
-    LaunchedEffect(state.tutorialStep) {
-        val fromStep = previousStep
-        val toStep = state.tutorialStep
-        val fromRect = previousHighlight
-        val toRect = highlightRect
-
-        // overlayAlpha 애니메이션 (2→3, 3→4, 4→5, 5→6 포함 전체 step 대응)
-        val targetAlpha = when (state.currentTargetKey) {
-            TutorialTargetKey.EMPTY,
-            TutorialTargetKey.END -> 0f
-
-            TutorialTargetKey.NOTIFICATION -> 0.3f
-            TutorialTargetKey.NOTIFICATION_COMPLETE -> 0.7f
-
-            else -> 0.7f
-        }
-
-        val isMovingHighlightStep =
-            (fromStep == 0 && toStep == 1 || fromStep == 1 && toStep == 2) && fromRect != null && toRect != null
-
-        val highlightDuration = 700
-
-        launch {
-            explainAlphaAnim.snapTo(0f)
-
-            isVisible = true
-
-            when (toStep) {
-                0 -> explainAlphaAnim.snapTo(1f)
-
-                4, 6 -> {
-                    explainAlphaAnim.animateTo(
-                        targetValue = 1f,
-                        animationSpec = tween(durationMillis = 250)
-                    )
-                }
-
-                else -> {
-
-                    delay((highlightDuration * 0.9).toLong())
-                    explainAlphaAnim.animateTo(
-                        targetValue = 1f,
-                        animationSpec = tween(durationMillis = 250)
-                    )
-                }
-            }
-        }
-
-        launch {
-            overlayAlphaAnim.animateTo(
-                targetValue = targetAlpha,
-                animationSpec = tween(durationMillis = 300)
-            )
-        }
-
-        if (isMovingHighlightStep) {
-            // Rect 이동 애니메이션
-            launch {
-                rectAnim.animateTo(
-                    targetValue = toRect,
-                    animationSpec = tween(
-                        durationMillis = highlightDuration,
-                        easing = LinearOutSlowInEasing
-                    )
-                )
-            }
-        } else {
-            // Rect 이동 애니메이션이 필요 없는 경우: 그냥 스냅
-            rectAnim.snapTo(toRect ?: Rect(0f, 0f, 0f, 0f))
-        }
-
-        previousStep = toStep
-        previousHighlight = toRect
-    }
+    val animatedHighlight = transitionState.currentRect
 
     val textTopDp = remember(highlightRect) {
         highlightRect?.let {
@@ -204,13 +103,13 @@ internal fun TutorialColumn(
         } ?: 24.dp
     }
 
-    val textBottomDp = remember(highlightRect) {
+    val textBottomDp = remember(highlightRect, screenHeightPx) {
         highlightRect?.let {
             with(density) { screenHeightPx.toDp() - it.top.toDp() } + 24.dp
         } ?: 24.dp
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = modifier.fillMaxSize()) {
         MainContent(
             state = state,
             refreshState = refreshState,
@@ -226,27 +125,26 @@ internal fun TutorialColumn(
         if (!state.isTutorialComplete) {
             TutorialOverlay(
                 density = density,
-                overlayAlaph = overlayAlphaAnim.value,
+                overlayAlpha = transitionState.overlayAlpha,
                 highlightRect = animatedHighlight,
                 onClickNextStep = onClickNextStep
             )
 
-            if (!state.currentTargetKey.shouldHideExplain() && isVisible) {
+            if (!state.currentTargetKey.shouldHideExplain() && isExplainVisible) {
                 Column(
                     modifier = Modifier
-                        .align(state.currentTargetKey.loc.alignment),
+                        .align(state.currentTargetKey.loc.alignment)
+                        .graphicsLayer { alpha = transitionState.explainAlpha },
                     verticalArrangement = Arrangement.spacedBy(20.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     ExplainText(
-                        modifier = Modifier
-                            .padding(
-                                start = 32.dp,
-                                top = if (state.currentTargetKey.loc.isTop()) textTopDp else 0.dp,
-                                end = 32.dp,
-                                bottom = if (!state.currentTargetKey.loc.isTop()) textBottomDp else 0.dp
-                            )
-                            .alpha(explainAlphaAnim.value),
+                        modifier = Modifier.padding(
+                            start = 32.dp,
+                            top = if (state.currentTargetKey.loc.isTop()) textTopDp else 0.dp,
+                            end = 32.dp,
+                            bottom = if (!state.currentTargetKey.loc.isTop()) textBottomDp else 0.dp
+                        ),
                         firstContent = stringResource(state.currentTargetKey.textGroupRes.firstContent),
                         highlightContent = stringResource(state.currentTargetKey.textGroupRes.highlightContent),
                         secondContent = stringResource(state.currentTargetKey.textGroupRes.secondContent)
@@ -254,9 +152,7 @@ internal fun TutorialColumn(
 
                     if (state.currentTargetKey == TutorialTargetKey.NOTIFICATION_COMPLETE) {
                         YakssokButton(
-                            modifier = Modifier
-                                .padding(horizontal = 72.dp)
-                                .alpha(explainAlphaAnim.value),
+                            modifier = Modifier.padding(horizontal = 72.dp),
                             text = stringResource(R.string.tutorial_button),
                             contentColor = YakssokTheme.color.grey50,
                             onClick = onClickNextStep
@@ -273,6 +169,93 @@ internal fun TutorialColumn(
             }
         }
     }
+}
+
+@Composable
+private fun rememberTutorialTransitionState(
+    tutorialStep: Int,
+    currentTargetKey: TutorialTargetKey,
+    highlightRect: Rect?,
+    changeExplainVisible: () -> Unit
+): TutorialTransitionState {
+    val state = remember {
+        TutorialTransitionState(
+            initialOverlayAlpha = OVERLAY_ALPHA_FULL,
+            initialRect = Rect.Zero
+        )
+    }
+
+    var previousStep by remember { mutableIntStateOf(tutorialStep) }
+    var previousHighlight by remember { mutableStateOf<Rect?>(null) }
+
+    LaunchedEffect(tutorialStep, highlightRect) {
+        val fromStep = previousStep
+        val toStep = tutorialStep
+        val fromRect = previousHighlight
+        val toRect = highlightRect
+
+        val targetAlpha = when (currentTargetKey) {
+            TutorialTargetKey.EMPTY,
+            TutorialTargetKey.END -> 0f
+
+            TutorialTargetKey.NOTIFICATION -> OVERLAY_ALPHA_DIM
+            TutorialTargetKey.NOTIFICATION_COMPLETE -> OVERLAY_ALPHA_FULL
+            else -> OVERLAY_ALPHA_FULL
+        }
+
+        val isMovingHighlightStep =
+            (fromStep == 0 && toStep == 1 || fromStep == 1 && toStep == 2) && fromRect != null && toRect != null
+
+        launch {
+            state.explainAlphaAnim.snapTo(0f)
+
+            changeExplainVisible()
+
+            when (toStep) {
+                0 -> state.explainAlphaAnim.snapTo(1f)
+                4, 6 -> {
+                    state.explainAlphaAnim.animateTo(
+                        targetValue = 1f,
+                        animationSpec = tween(durationMillis = FADE_DURATION)
+                    )
+                }
+
+                else -> {
+                    delay((HIGHLIGHT_DURATION * 0.9).toLong())
+                    state.explainAlphaAnim.animateTo(
+                        targetValue = 1f,
+                        animationSpec = tween(durationMillis = FADE_DURATION)
+                    )
+                }
+            }
+        }
+
+        launch {
+            state.overlayAlphaAnim.animateTo(
+                targetValue = targetAlpha,
+                animationSpec = tween(durationMillis = OVERLAY_FADE_DURATION)
+            )
+        }
+
+        if (isMovingHighlightStep) {
+            launch {
+                state.rectAnim.animateTo(
+                    targetValue = toRect,
+                    animationSpec = tween(
+                        durationMillis = HIGHLIGHT_DURATION,
+                        easing = LinearOutSlowInEasing
+                    )
+                )
+            }
+        } else {
+            state.rectAnim.snapTo(toRect ?: Rect.Zero)
+        }
+
+        previousStep = toStep
+        previousHighlight = toRect
+    }
+
+    return state
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -298,7 +281,8 @@ private fun MainContent(
                 onNavigateAlert = onNavigateAlert,
                 onNavigateMy = onNavigateMyPage
             )
-        }) {
+        }
+    ) {
         if (state.isLoading) {
             HomeSkeleton(showFeedbackSection = true)
         } else {
@@ -310,42 +294,46 @@ private fun MainContent(
 @Composable
 private fun TutorialOverlay(
     density: Density,
-    overlayAlaph: Float = 0.7f,
+    overlayAlpha: Float = 0.7f,
     highlightRect: Rect?,
     onClickNextStep: () -> Unit
 ) {
-    val overlayRadius = 16.dp.toPx(density)
-    val overlayColor = YakssokTheme.color.black.copy(alpha = overlayAlaph)
-
+    val overlayRadiusPx = 16.dp.toPx(density)
+    val overlayBaseColor = YakssokTheme.color.black
     val interactionSource = remember { MutableInteractionSource() }
 
-    var canvasSize by remember { mutableStateOf(Size.Zero) }
-    val overlayPath = remember(highlightRect, canvasSize, overlayRadius) {
-        Path().apply {
-            addRect(Rect(0f, 0f, canvasSize.width, canvasSize.height))
-            highlightRect?.let {
-                addRoundRect(
-                    RoundRect(
-                        rect = it, cornerRadius = CornerRadius(overlayRadius, overlayRadius)
-                    )
-                )
-            }
-            fillType = PathFillType.EvenOdd
-        }
-    }
-
-    Canvas(
+    Spacer(
         modifier = Modifier
             .fillMaxSize()
-            .onSizeChanged { size -> canvasSize = size.toSize() }
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = onClickNextStep
             )
-    ) {
-        drawPath(path = overlayPath, color = overlayColor)
-    }
+            .drawWithCache {
+                val overlayPath = Path().apply {
+                    addRect(Rect(0f, 0f, size.width, size.height))
+                    highlightRect?.let { rect ->
+                        if (rect.width > 0 && rect.height > 0) {
+                            addRoundRect(
+                                RoundRect(
+                                    rect = rect,
+                                    cornerRadius = CornerRadius(overlayRadiusPx, overlayRadiusPx)
+                                )
+                            )
+                        }
+                    }
+                    fillType = PathFillType.EvenOdd
+                }
+
+                onDrawBehind {
+                    drawPath(
+                        path = overlayPath,
+                        color = overlayBaseColor.copy(alpha = overlayAlpha)
+                    )
+                }
+            }
+    )
 }
 
 @Composable
@@ -382,12 +370,18 @@ private fun ExampleNotification(
     density: Density,
     onMeasure: (Rect) -> Unit
 ) {
+    var measuredRect by remember { mutableStateOf<Rect?>(null) }
+
     Row(
         modifier = Modifier
             .padding(top = 72.dp, start = 16.dp, end = 16.dp)
             .fillMaxWidth()
-            .onGloballyPositioned {
-                onMeasure(it.toRect(density))
+            .onGloballyPositioned { coordinates ->
+                val newRect = coordinates.toRect(density)
+                if (measuredRect != newRect) {
+                    measuredRect = newRect
+                    onMeasure(newRect)
+                }
             }
             .clip(RoundedCornerShape(16.dp))
             .background(YakssokTheme.color.grey150)

--- a/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/model/TutorialModel.kt
+++ b/feature/home/src/main/kotlin/com/pillsquad/yakssok/feature/home/model/TutorialModel.kt
@@ -1,0 +1,41 @@
+package com.pillsquad.yakssok.feature.home.model
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector4D
+import androidx.compose.animation.core.TwoWayConverter
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.geometry.Rect
+
+internal const val HIGHLIGHT_DURATION = 700
+internal const val FADE_DURATION = 250
+internal const val OVERLAY_FADE_DURATION = 300
+internal const val OVERLAY_ALPHA_FULL = 0.7f
+internal const val OVERLAY_ALPHA_DIM = 0.3f
+
+internal val RectVectorConverter = TwoWayConverter<Rect, AnimationVector4D>(
+    convertToVector = { rect ->
+        AnimationVector4D(rect.left, rect.top, rect.right, rect.bottom)
+    },
+    convertFromVector = { vector ->
+        Rect(vector.v1, vector.v2, vector.v3, vector.v4)
+    }
+)
+
+@Stable
+internal class TutorialTransitionState(
+    initialOverlayAlpha: Float,
+    initialRect: Rect
+) {
+    val rectAnim = Animatable(initialRect, RectVectorConverter)
+    val overlayAlphaAnim = Animatable(initialOverlayAlpha)
+    val explainAlphaAnim = Animatable(0f)
+
+    val overlayAlpha: Float
+        get() = overlayAlphaAnim.value
+
+    val explainAlpha: Float
+        get() = explainAlphaAnim.value
+
+    val currentRect: Rect
+        get() = rectAnim.value
+}


### PR DESCRIPTION
## 🚀 작업 내용
- Tutorial Animatable 적용

## ✅ 작업 상세
각 단계 별 동작의 정의를 세움

```
0 → 1, 1 → 2
highlightRect는 크기와 위치가 이동되는 애니메이션을 적용
ExplainText는 터치하면 즉시 없어지고 highlightRect가 도착 이후에 ExplainText가 250ms로 fadein

2 → 3
ExplainText 안보임. rect 없음.
overlay가 투명해짐

3 → 4
0.7f로 overlayAlpha가 서서히 설정됨.
highlightRect 나타나고 ExplainText가 fadein

4 → 5
overlay가 0.3로 서서히 바뀜.
0.3으로 서서히 바뀐 후에 notificaiton이 뜸. highlightRect도 서서히 나타나면 좋을 듯

5 → 6
0.7f로 서서히 변경되면서 그에 맞는 속도로 ExplainText랑 버튼이 fadein
```

단계에 따라서 explainAlphaAnim, rectAnim, overlayAlphaAnim 등을 정의한 시간에 맞춰
animateTo() 하도록 구현함.

즉시 사라져야 하는 단계에서는 snapTo()를 활용하여 값을 핸들링함.

0 -> 1, 1 -> 2에서 단계 변경에 따라서 ExplainText가 없어지도록 snapTo(0f)를 했지만 레이아웃 재배치가 먼저 진행되고
그 다음 snapTo(0f)가 실행되는 현상이 발생함.
=> isExplainVisible이라는 값을 생성함. highlightRect가 변경되면 false로 자동 설정되어 레이아웃 재배치 단계에서 렌더링되지 않도록 함. launch 단계에서 snapTo(0f)가 실행되면 해당 값을 true로 바꾸고 fade-in되는 모습을 보여줬음.


## 📹 스크린샷

https://github.com/user-attachments/assets/01a94374-d961-4394-8f33-23068886a325
